### PR TITLE
Add preprocessing code and helpder functions

### DIFF
--- a/00-documentation/0_00-legacy-bmf.qmd
+++ b/00-documentation/0_00-legacy-bmf.qmd
@@ -21,26 +21,51 @@ library( knitr )       # pretty tables
 library( DiagrammeR )  # drawing diagrams
 library( ggthemes )    # graphics 
 library( gridExtra )   # graphics
+library( log4r )
 
 # CUSTOM FUNCTIONS: fable()
 source( "R/functions.R" )
 
 # FACTOR LABELS  
 source( "data/DICTIONARIES.R" )
+
+# Logging
+harmonize_logger = create_logger(
+  logfile_path = "logs/bmf_download_log.txt"
+  )
 ```
 
 
-## Data from Step-00 PreProcessing
+# Preprocessing the BMFs
 
-```{r, cache=T}
-d <- readRDS( "data/BMF-LABELED-TEMP.rds" )
+## Retrieving BMF urls
+
+There are 2 sources of BMFs that undergo harmonization.
+
+1. NCCS'BMF archive (legacy BMF)
+2. Newly released BMFs from the IRS (raw BMF)
+
+```{r, cache=T, eval=FALSE}
+bmf_url_ls <- c(
+  get_s3_bucket_contents( bucket_name = "nccsdata",
+                          bucket_folder = "raw/bmf/",
+                          bucket_url = BUCKET_LS$nccsdata ),
+  get_s3_bucket_contents( bucket_name = "nccsdata",
+                          bucket_folder = "legacy/bmf/",
+                          bucket_url = BUCKET_LS$nccsdata )
+)
 ```
 
+## Downloading BMFs
 
+```{r, eval=FALSE}
+download_files(
+  urls_ls = bmf_url_ls, 
+  dest_folder = "data/raw/"
+)
+```
 
-
-
-
+Legacy and raw BMF should now be saved to the `data/raw/` folder.
 
 <style>
 

--- a/00-documentation/R/functions.R
+++ b/00-documentation/R/functions.R
@@ -43,3 +43,78 @@ fable <- function( x, p=FALSE, dig=3, as.factor=FALSE ){
 # fable( d$NCCS_LEVEL_3 )
 # fable( d$NCCS_LEVEL_3, p=TRUE )      # as proportions
 # fable( d$NCCS_LEVEL_3, as.factor=T ) # orders by label, not count
+
+#' @title Function to get the contents of an S3 Bucket
+#' @param bucket_name character scalar. Name of S3 Bucket
+#' @param bucket_folder character scalar. Folder to get contents from
+#' @param bucket_url character scalar. Base url of S3 Bucket
+get_s3_bucket_contents <- function( bucket_name, bucket_folder, bucket_url ){
+  
+  s3 <- paws::s3()
+  obj <- s3$list_objects( Bucket = bucket_name )
+  keys <- unlist( purrr::map( obj$Contents, purrr::pluck, "Key" ) )
+  keys <- keys[ grepl( bucket_folder, keys ) ]
+  
+  expr <- sprintf( "(?<=%s).*", bucket_folder )
+  filenames <- stringr::str_extract( keys,  expr )
+  filenames <- filenames[ nchar( filenames ) > 1 ]
+  
+  s3_urls <- paste0( bucket_url,
+                     bucket_folder,
+                     filenames )
+  
+  s3_ls <- as.list( s3_urls )
+  names( s3_ls ) <- filenames
+  
+  return( s3_ls )
+  
+}
+
+#' @title Function to download raw data to a destination folder
+#' @description This function downloads .dat, .csv or .xlsx data to a destination folder and logs errors
+#' @param url_ls list. List of URLs (character)
+#' @param destfolder character scalar. String indicating destination folder.
+#' @param logger logging object. Logger to log failed downloads
+#' @return message indicating that download is complete.
+
+download_raw_data <- function(url_ls, destfolder, logger) {
+  purrr::map2(
+    .x = unlist(url_ls),
+    .y = names(url_ls),
+    .f = function(x, y) {
+      tryCatch({
+        message(sprintf("Downloading file: %s", y))
+        if (grepl("dat", y)) {
+          df <- readr::read_table(x)
+        }
+        else if (grepl("csv", y)) {
+          df <- data.table::fread(x)
+        }
+        else if (grepl("xlsx", y)) {
+          df <- rio::import(x)
+        }
+        
+      }, warning = function(w) {
+        log4r::warn(logger, message = w)
+        
+      }, error = function(e) {
+        log4r::error(logger, message = sprintf("Failed to download file: %s from %s", y, x))
+        log4r::error(logger, message = e)
+        
+      }, finally = {
+        message("Moving to Next File")
+        
+      })
+      
+      file_root <- gsub("\\..*", "", y)
+      destfile <- paste0(destfolder, file_root, ".csv")
+      
+      rio::export(df, destfile)
+      
+    },
+    .progress = "Download Progress"
+  )
+  
+  return(message("Download Complete"))
+  
+}


### PR DESCRIPTION
This commit downloads and saves BMF files from NCCS' S3 buckets to a folder on the user's device.

It also introduces logging.