### PR TITLE
Fix duplicate combined_* columns in Master BMF; refresh README

### DIFF
--- a/R/master_bmf_builder.R
+++ b/R/master_bmf_builder.R
@@ -340,7 +340,8 @@ build_master_bmf <- function(con,
              SUM(n_vintages)       OVER (PARTITION BY ein) AS bmf_vintages_observed
         FROM combined
     )
-    SELECT * EXCLUDE (rn, first_vintage_ym, last_vintage_ym, n_vintages),
+    SELECT * EXCLUDE (rn, first_vintage_ym, last_vintage_ym, n_vintages,
+                      combined_first_vintage_ym, combined_last_vintage_ym),
            combined_first_vintage_ym AS first_vintage_ym,
            combined_last_vintage_ym  AS last_vintage_ym,
            combined_last_vintage_ym  AS bmf_vintage_ym,

--- a/R/master_bmf_builder.R
+++ b/R/master_bmf_builder.R
@@ -1,6 +1,9 @@
 # ============================================================================
 # master_bmf_builder.R
 #
+# Producer of the bmf-master contract — see
+# https://github.com/UrbanInstitute/nccs-contracts/blob/main/contracts/bmf-master.yml
+#
 # Builds the Master BMF: one row per EIN, drawn from the most-recent vintage
 # in which that EIN appears across both the current monthly BMF pipeline
 # (s3://nccsdata/processed/bmf/) and the legacy 501CX-NONPROFIT-PX pipeline

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ to `data/` locally and (when `ENABLE_S3_UPLOAD = TRUE`) uploads to the
 | **Legacy BMF** | `R/run_legacy_pipeline.R` | Harmonizes an NCCS 501CX-NONPROFIT-PX vintage (1989–2022) to the current schema, then runs the same transforms | `processed/bmf-legacy/YYYY_MM/` |
 | **Master BMF** | `R/run_master_pipeline.R` | Consolidates every processed vintage (current + legacy) into one row per EIN | `master/bmf/` |
 | **State marts** | `R/run_master_state_marts.R` | Splits the geocoded Master BMF into one file per US state/territory | `master/bmf/state_marts/` |
-| **Geocoding** | `R/run_geocoding.R`, `R/run_master_geocoding.R` | Two-phase (export → merge) workflow that appends lat/lon + FIPS via the Urban Institute geocoder | `geocoding/bmf/YYYY_MM/`, `geocoding/master/` |
+| **Geocoding** | `R/run_geocoding.R`, `R/run_master_geocoding.R` | Two-phase (export → merge) workflow that appends lat/lon + FIPS via the Urban Institute geocoder | `geocoding/bmf/YYYY_MM/`, `geocoding/bmf-master/` |
 
 ## Data flow
 

--- a/README.md
+++ b/README.md
@@ -1,36 +1,163 @@
-# Overview
+# nccs-data-bmf
 
-This repository contains the code and documentation needed to harmonize prior and current Business Master File (BMF) extracts from NCCS and the IRS respectively. It also contains the code needed to create the unified BMF, that aggregates unique records from all prior BMFs to create a consolidated list of active and inactive nonprofit organizations.
+Code and documentation for harmonizing IRS Business Master File (BMF) data —
+extracts of the ~1.9 million nonprofit organizations exempt from federal income
+tax. This repo ingests both the **current monthly IRS BMF** and **NCCS legacy
+BMF** vintages, harmonizes them to a single schema, geocodes them, and
+consolidates them into a **Master BMF** with one row per EIN.
 
-# NCCS Legacy BMFs
+**Documentation:** [BMF Research Guidebook](https://urbaninstitute.github.io/nccs-data-bmf/index.html)
 
-NCCS previously processed each BMF released by the IRS by creating separate data dictionaries and schemas for each dictionary. 
+## What this repo produces
 
-Our current data engineering methodology harmonizes columns across each year, ensuring that variables are consistently named and have standardized data types. 
+The repository contains four pipelines plus a geocoding workflow. Each writes
+to `data/` locally and (when `ENABLE_S3_UPLOAD = TRUE`) uploads to the
+`nccsdata` S3 bucket.
 
-Additionally, we discard metadata variables that cannot be reconstructed either due to missing documentation or removal by the IRS from later BMF releases.
+| Pipeline | Orchestrator | What it does | S3 output prefix |
+|----------|-------------|--------------|------------------|
+| **Current BMF** | `R/run_pipeline.R` | Transforms a monthly IRS BMF extract through 11 phases into cleaned, validated columns | `processed/bmf/YYYY_MM/` |
+| **Legacy BMF** | `R/run_legacy_pipeline.R` | Harmonizes an NCCS 501CX-NONPROFIT-PX vintage (1989–2022) to the current schema, then runs the same transforms | `processed/bmf-legacy/YYYY_MM/` |
+| **Master BMF** | `R/run_master_pipeline.R` | Consolidates every processed vintage (current + legacy) into one row per EIN | `master/bmf/` |
+| **State marts** | `R/run_master_state_marts.R` | Splits the geocoded Master BMF into one file per US state/territory | `master/bmf/state_marts/` |
+| **Geocoding** | `R/run_geocoding.R`, `R/run_master_geocoding.R` | Two-phase (export → merge) workflow that appends lat/lon + FIPS via the Urban Institute geocoder | `geocoding/bmf/YYYY_MM/`, `geocoding/master/` |
 
-# IRS BMF Extracts
+## Data flow
 
-Currently released IRS BMF Extracts are also harmonized with the following metadata variables created from the harmonized variables:
+```
+                                  ┌─────────────────────────┐
+  raw/bmf/  (monthly IRS) ──────► │  Current BMF pipeline    │ ──► processed/bmf/YYYY_MM/
+                                  └─────────────────────────┘            │
+                                                                         ▼
+  legacy/bmf/ (NCCS 501CX) ─────► ┌─────────────────────────┐     ┌──────────────┐
+                                  │  Legacy BMF pipeline     │ ──► │ Master BMF   │ ──► master/bmf/
+                                  └─────────────────────────┘     │ (1 row/EIN)  │
+  processed/bmf-legacy/YYYY_MM/ ───────────────────────────────► └──────────────┘
+                                                                         │
+                                                                geocode + split
+                                                                         ▼
+                                                              master/bmf/state_marts/
+```
 
-* `EIN2` is created from `EIN` by adding the following strings between the 9 digit EIN: `EIN-XX-XXXXXXX`. This ensures that the EIN is treated as a string and not a integer when saved in read in from `.csv` files without explicit data type handling.
-* `NTEEV2` is created from the `NTEE_IRS` column containing NTEE codes reported by nonprofits in the Form 990.
+## Harmonized metadata fields
 
-# Creating the Unified BMF
+The transforms standardize raw IRS/NCCS columns into ~76 cleaned, validated
+columns with human-readable code definitions joined from lookup tables. Notably:
 
-Updating the BMF requires the following steps:
+- **`ein`** — normalized to the standard `XX-XXXXXXX` string format
+  (see `R/ein.R`) so it survives CSV round-trips without being coerced to an
+  integer.
+- **`NTEEV2`** — derived from the reported NTEE code column (`NTEE_CD`) into the
+  NTEEv2 classification, including subsector and organization-type components
+  (see `R/transform_ntee_code.R`). Legacy pre-2003 5-character NTEE codes are
+  crosswalked via `data/lookup/ntee_legacy_5char_lookup.csv`.
 
-1. Download the latest BMF data from the IRS.
-2. Create and clean the latest columns.
-3. Geocode the BMF and append various FIPs codes to the Latitude and Longitude columns.
-4. Update the financial columns with the latest e-filed data.
-5. Update the existing unified BMF with the 2025 data.
+## The Master BMF
 
-These steps need to be run periodically whenever a new BMF is published.
+The Master BMF is the consolidated, one-row-per-EIN view of every nonprofit
+ever observed across both the current monthly and legacy pipelines. It is built
+with DuckDB (`union_by_name` stack + dedup) over the processed CSVs of both
+pipelines; the most-recent vintage wins, with the current pipeline winning on
+`vintage_ym` ties. Each row carries the latest vintage's contents plus
+provenance markers:
+
+`first_vintage_ym`, `last_vintage_ym`, `bmf_vintage_ym`, `first_year_in_bmf`,
+`last_year_in_bmf`, `bmf_vintages_observed`, `bmf_source`.
+
+The Master BMF carries **86 columns**: the `union_by_name` superset of the
+transformed columns across all stacked vintages (slightly wider than the
+~76 single-vintage schema), plus the 7 lineage columns above. It is rebuilt
+from scratch each run (a single living artifact, overwritten in place), not
+updated incrementally. See [docs/11-master-bmf.qmd](docs/11-master-bmf.qmd).
+
+## Running the pipelines
+
+AWS credentials must be configured (env vars or `~/.aws/credentials`). Run from
+the project root in R/RStudio.
+
+### Current monthly BMF
+
+```r
+# Most recent BMF in S3 (default):
+source("R/run_pipeline.R")
+
+# A specific month:
+BMF_YEAR <- 2026
+BMF_MONTH <- 3
+source("R/run_pipeline.R")
+
+# List available months:
+source("R/config.R"); list_available_bmf_files()
+```
+
+Pipeline flags in `run_pipeline.R`: `ENABLE_CHECKPOINTS`, `STRICT_QUALITY_GATES`,
+`ENABLE_S3_UPLOAD`, `CHECKPOINT_DIR`.
+
+### Legacy BMF (1989–2022)
+
+```r
+# A specific vintage from S3:
+LEGACY_BMF_YEAR <- 2013; LEGACY_BMF_MONTH <- 7
+source("R/run_legacy_pipeline.R")
+
+# Or a local file (skips S3 download):
+LEGACY_BMF_FILE <- "data/raw/legacy/BMF-2013-07-501CX-NONPROFIT-PX.csv"
+source("R/run_legacy_pipeline.R")
+```
+
+To batch every legacy vintage on EC2, see `scripts/run_all_legacy.sh` and
+[docs/10-ec2-batch-processing.qmd](docs/10-ec2-batch-processing.qmd).
+
+### Master BMF and state marts
+
+```r
+source("R/run_master_pipeline.R")       # build the Master BMF
+source("R/run_master_state_marts.R")    # split geocoded master by state
+```
+
+Or on EC2: `bash scripts/run_master.sh`.
+
+### Geocoding
+
+```r
+# Phase 1 — export address batches:
+GEOCODING_MODE <- "export"; source("R/run_geocoding.R")
+# ... upload to the Urban geocoder, download results ...
+# Phase 2 — merge geocoded results back in:
+GEOCODING_MODE <- "merge";  source("R/run_geocoding.R")
+```
+
+The Master BMF has its own geocoding orchestrator, `R/run_master_geocoding.R`,
+following the same export/merge pattern.
+
+## Outputs
+
+Local outputs land under `data/` (`processed/`, `intermediate/`, `master/`,
+`geocoding/`, `quality/`); the same artifacts upload to the `nccsdata` S3
+bucket when `ENABLE_S3_UPLOAD = TRUE`. The bucket layout and "which dataset
+should I use?" guidance live in the bucket's own README
+([`data/s3-readme/README.md`](data/s3-readme/README.md)), which is published to
+the bucket root.
+
+## Published lookup tables (downstream contract)
+
+The 17 BMF code-definition lookup tables are published to S3 as a stable,
+versioned contract for downstream consumers (notably the sibling `nccsdata` R
+package):
+
+- `s3://nccsdata/lookups/bmf/{YYYY_MM}/...` — vintage snapshot + `MANIFEST.json`
+- `s3://nccsdata/lookups/bmf/latest/...` — mirror of the most recent vintage
+
+Publishing runs automatically as the final phase of `run_master_pipeline.R`, or
+standalone via `source("R/run_publish_lookups.R")`. **Any edit to
+`data/lookup/bmf_code_lookup.xlsx` or `data/lookup/ntee_legacy_5char_lookup.csv`
+requires re-running the publish step**, or downstream consumers go stale. See
+the "Published artifacts" section of `CLAUDE.md` for the full path contract.
 
 ## Documentation
 
-[BMF Research Guidebook](https://urbaninstitute.github.io/nccs-data-bmf/index.html)
+- [BMF Research Guidebook](https://urbaninstitute.github.io/nccs-data-bmf/index.html) — full pipeline documentation (Quarto)
+- [Latest Quality Report](https://urbaninstitute.github.io/nccs-data-bmf/quality-reports/index.html)
+- [IRS BMF Extract source](https://www.irs.gov/charities-non-profits/exempt-organizations-business-master-file-extract-eo-bmf)
 
-[Quality Report (March 2026)](https://urbaninstitute.github.io/nccs-data-bmf/quality-reports/bmf_2026_03_quality_report.html)
+Build the guidebook locally: `cd docs && quarto render`.

--- a/data/s3-readme/README.md
+++ b/data/s3-readme/README.md
@@ -151,7 +151,7 @@ carries the most-recent vintage's contents plus first/last vintage markers
 ### `master/bmf/state_marts/`
 
 Per-state data marts derived from the geocoded Master BMF
-(`geocoding/master/merged/bmf_master_geocoded.parquet`). Built so end
+(`geocoding/bmf-master/merged/bmf_master_geocoded.parquet`). Built so end
 users can pull only the state(s) they need instead of the full ~3 GB
 unified file. Partition key is `org_addr_state` (cleaned mailing
 state); rows with missing state are bucketed into `ZZ`. Built by
@@ -166,7 +166,7 @@ state); rows with missing state are bucketed into `ZZ`. Built by
   APO/FPO codes (AA, AE, AP), Compact-of-Free-Association codes (FM,
   MH, PW), and a `ZZ` missing-state bucket
 - **Example:** `master/bmf/state_marts/csv/bmf_master_NY.csv`
-- **Input:** `geocoding/master/merged/bmf_master_geocoded.parquet`
+- **Input:** `geocoding/bmf-master/merged/bmf_master_geocoded.parquet`
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

Two substantive changes plus the original Copilot-wire-up test marker:

1. **Bug fix — `R/master_bmf_builder.R`:** `combined_first_vintage_ym` and `combined_last_vintage_ym` were leaking into the Master BMF output alongside their canonical aliases (`first_vintage_ym` / `last_vintage_ym`), because the final `SELECT * EXCLUDE (...)` kept the window-computed `combined_*` columns while the aliases re-added them. Adding them to the `EXCLUDE` list drops the duplicates. **Brings the Master BMF from 88 → 86 columns on the next rebuild.** Verified against the live S3 data dictionary: the `combined_*` columns had identical stats to their canonical counterparts and empty descriptions.

2. **Docs — `README.md`:** full rewrite to reflect current architecture (current monthly, legacy, Master BMF, state marts, geocoding), corrects the stale `EIN2`/`NTEEV2` field docs, documents the 86-column Master BMF schema and lineage markers, and defers the S3 layout to the bucket README.

Also retains the original contract-pointer comment at the top of `master_bmf_builder.R` naming the `bmf-master` contract.

## Notes

- The Master BMF artifact on S3 is still 88 columns until `run_master_pipeline.R` is re-run; the README documents the intended post-fix (86) state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)