### PR TITLE
Standard _manifest.json reference (ADR 0014) + bmf-lookups & bmf-legacy

### DIFF
--- a/R/manifest.R
+++ b/R/manifest.R
@@ -1,0 +1,153 @@
+# ============================================================================
+# manifest.R
+#
+# Reference implementation of the contract-standard `_manifest.json` shape
+# defined in nccs-contracts ADR 0014 ("Standardize Manifest Shape Across
+# Producers"). Every NCCS producer emits this same shape so a single
+# drift-detection validator and a single cross-repo agent prompt can read
+# any producer's manifest.
+#
+# This file is the canonical reference: bmf-lookups (R/publish_lookups.R)
+# uses it directly; bmf-master / bmf-master-geocoded / bmf-legacy copy the
+# same call pattern (adapting only their own outputs + inputs).
+#
+# Schema (ADR 0014 §Schema):
+#   {
+#     "vintage":  "<tag>",                # e.g. "2026_05" (until the ADR 0013
+#                                         #   v{YYYY.MM} flip) — matches the path
+#     "built_at": "2026-05-29T13:09:18Z", # ISO 8601, UTC, Z suffix
+#     "git_sha":  "0a7048d",              # short SHA (omitted if no git context)
+#     "inputs":   [ {uri, etag|sha256}, ... ],
+#     "files":    { "<basename>": {file, sha256, bytes, row_count?, columns?, year_counts?}, ... }
+#   }
+# ============================================================================
+
+#' Short git SHA of the repo containing the working directory.
+#'
+#' @return Character short SHA, or `NA_character_` when there is no git
+#'   context (ADR 0014 permits NA / omission in that case).
+#' @export
+git_short_sha <- function() {
+  out <- tryCatch(
+    system2("git", c("rev-parse", "--short", "HEAD"),
+            stdout = TRUE, stderr = FALSE),
+    error = function(e) NA_character_
+  )
+  if (length(out) == 0 || is.na(out[[1]]) || !nzchar(out[[1]])) {
+    return(NA_character_)
+  }
+  out[[1]]
+}
+
+#' Build and write a contract-standard `_manifest.json` (ADR 0014).
+#'
+#' Writes `_manifest.json` into `out_dir` and returns the manifest list.
+#' Callers own the S3 upload (and any `latest/` mirror) because that part
+#' differs per producer — `bmf-lookups` mirrors to `latest/`, `bmf-legacy`
+#' does not (it is an append-only archive; see its contract and ADR 0013).
+#'
+#' @param vintage Vintage tag string. Use the same value that appears in
+#'   the S3 path (e.g. `"2026_05"`; flips to `"v2026.05"` when ADR 0013's
+#'   vintage-format migration runs).
+#' @param out_dir Local directory the output files live in; the manifest
+#'   is written here as `_manifest.json`.
+#' @param outputs Named list, one entry per output artifact. Each entry is
+#'   a list with `path` (local file path, required) and optionally
+#'   `row_count` (int), `columns` (character vector), `year_counts`
+#'   (named int). `sha256` and `bytes` are computed here.
+#' @param inputs List of input descriptors, each a list with `uri`
+#'   (required) plus `etag` (S3 inputs) or `sha256` (repo:// / http
+#'   inputs). Pass `list()` when none are recorded.
+#' @param git_sha Short git SHA (default: `git_short_sha()`).
+#'
+#' @return Invisibly, `list(manifest = <list>, path = <chr>)`.
+#' @export
+write_manifest <- function(vintage, out_dir, outputs, inputs = list(),
+                           git_sha = git_short_sha()) {
+  if (!requireNamespace("digest",   quietly = TRUE)) stop("Package 'digest' required.")
+  if (!requireNamespace("jsonlite", quietly = TRUE)) stop("Package 'jsonlite' required.")
+  stopifnot(is.list(outputs), length(outputs) > 0)
+
+  drop_null <- function(x) x[!vapply(x, is.null, logical(1))]
+
+  file_entries <- lapply(outputs, function(o) {
+    if (is.null(o$path) || !file.exists(o$path)) {
+      stop(sprintf("write_manifest: output path missing or unreadable: %s",
+                   if (is.null(o$path)) "<NULL>" else o$path))
+    }
+    drop_null(list(
+      file        = basename(o$path),
+      sha256      = digest::digest(file = o$path, algo = "sha256"),
+      bytes       = as.integer(file.size(o$path)),
+      row_count   = if (!is.null(o$row_count))   as.integer(o$row_count) else NULL,
+      columns     = if (!is.null(o$columns))     as.list(o$columns)      else NULL,
+      year_counts = if (!is.null(o$year_counts)) as.list(o$year_counts)  else NULL
+    ))
+  })
+  # Key the files object by basename, as it appears at the vintage prefix.
+  names(file_entries) <- vapply(outputs, function(o) basename(o$path), character(1))
+
+  manifest <- drop_null(list(
+    vintage  = vintage,
+    built_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+    git_sha  = if (length(git_sha) && !is.na(git_sha)) git_sha else NULL,
+    inputs   = inputs,
+    files    = file_entries
+  ))
+
+  if (!dir.exists(out_dir)) dir.create(out_dir, recursive = TRUE)
+  path <- file.path(out_dir, "_manifest.json")
+  jsonlite::write_json(manifest, path, pretty = TRUE, auto_unbox = TRUE)
+  invisible(list(manifest = manifest, path = path))
+}
+
+#' Describe one repo-local input for the manifest `inputs[]` array.
+#'
+#' @param repo_relpath Path inside the producer repo (e.g.
+#'   `"data/lookup/bmf_code_lookup.xlsx"`). Recorded as a `repo://` URI.
+#' @param abs_path Absolute path used to compute the sha256 (default:
+#'   `here::here(repo_relpath)`).
+#' @return A list `{uri, sha256}` for one `inputs[]` entry.
+#' @export
+manifest_input_repo <- function(repo_relpath, abs_path = here::here(repo_relpath)) {
+  list(
+    uri    = paste0("repo://", repo_relpath),
+    sha256 = digest::digest(file = abs_path, algo = "sha256")
+  )
+}
+
+#' Fetch an existing remote `_manifest.json` for idempotent-skip decisions.
+#'
+#' @param s3_key Full S3 key of the manifest.
+#' @param bucket Bucket name.
+#' @return Parsed manifest list, or `NULL` if absent/unreadable.
+#' @export
+read_existing_manifest <- function(s3_key, bucket) {
+  exists <- tryCatch(
+    aws.s3::object_exists(object = s3_key, bucket = bucket),
+    error = function(e) FALSE
+  )
+  if (!isTRUE(exists)) return(NULL)
+  tryCatch({
+    raw <- aws.s3::get_object(object = s3_key, bucket = bucket)
+    jsonlite::fromJSON(rawToChar(raw), simplifyVector = FALSE)
+  }, error = function(e) {
+    message(sprintf("Could not read remote manifest s3://%s/%s: %s",
+                    bucket, s3_key, e$message))
+    NULL
+  })
+}
+
+#' Has `file_key` (a basename) the same sha256 in the remote manifest?
+#'
+#' @param remote_manifest Parsed manifest list from `read_existing_manifest()`.
+#' @param file_key The file's basename, as keyed in `manifest$files`.
+#' @param sha256 The freshly computed sha256 to compare.
+#' @return `TRUE` only when the remote records an identical sha256.
+#' @export
+manifest_unchanged <- function(remote_manifest, file_key, sha256) {
+  if (is.null(remote_manifest)) return(FALSE)
+  entry <- remote_manifest$files[[file_key]]
+  if (is.null(entry) || is.null(entry$sha256)) return(FALSE)
+  identical(entry$sha256, sha256)
+}

--- a/R/publish_lookups.R
+++ b/R/publish_lookups.R
@@ -10,23 +10,35 @@
 #
 # Output:
 #   s3://nccsdata/lookups/bmf/{YYYY_MM}/{name}.csv
-#   s3://nccsdata/lookups/bmf/{YYYY_MM}/MANIFEST.json
-#   s3://nccsdata/lookups/bmf/latest/{name}.csv   (mirror of most-recent vintage)
-#   s3://nccsdata/lookups/bmf/latest/MANIFEST.json
+#   s3://nccsdata/lookups/bmf/{YYYY_MM}/_manifest.json   (ADR 0014 shape)
+#   s3://nccsdata/lookups/bmf/{YYYY_MM}/MANIFEST.json     (deprecated; byte
+#                                                          copy, 90-day window)
+#   s3://nccsdata/lookups/bmf/latest/{name}.csv          (mirror of newest vintage)
+#   s3://nccsdata/lookups/bmf/latest/_manifest.json
+#   s3://nccsdata/lookups/bmf/latest/MANIFEST.json        (deprecated copy)
 #
-# Idempotency: each file's sha256 is recorded in MANIFEST.json. On re-run,
+# Manifest: the contract-standard `_manifest.json` (nccs-contracts ADR 0014),
+# built via R/manifest.R::write_manifest(). This file is the reference
+# implementation other BMF producers copy. The legacy `MANIFEST.json` name
+# is dual-written (byte-identical) for one deprecation window per ADR 0014.
+#
+# Idempotency: each file's sha256 is recorded in _manifest.json. On re-run,
 # the existing remote manifest is fetched; any file whose hash is unchanged
-# is skipped. The convention `aws s3 sync` referenced elsewhere in the
-# repo is not used here because all existing S3 traffic in this codebase
-# goes through aws.s3::put_object — staying consistent with that pattern.
+# is skipped. All S3 traffic goes through aws.s3::put_object (upload_to_s3),
+# consistent with the rest of this codebase.
+#
+# Note (ADR 0013): the vintage path format flip from YYYY_MM to v{YYYY.MM}
+# is intentionally NOT done here — it is a breaking path change handled in a
+# separate, consumer-coordinated migration. This change is manifest-shape
+# only (ADR 0014).
 # ============================================================================
 
 #' Publish BMF lookup tables to S3
 #'
 #' Writes each entry of `lookup_ls` to a CSV under `lookup_dir`, builds a
-#' MANIFEST.json (file name, row count, columns, sha256), and uploads to
-#' s3://{bucket}/{s3_prefix}{vintage}/. Then mirrors the same files to
-#' s3://{bucket}/{s3_prefix}latest/.
+#' contract-standard `_manifest.json` (ADR 0014, via `write_manifest()`),
+#' and uploads to s3://{bucket}/{s3_prefix}{vintage}/. Then mirrors the same
+#' files to s3://{bucket}/{s3_prefix}latest/.
 #'
 #' @param lookups     Named list of data.tables/data.frames (default: lookup_ls).
 #' @param vintage     YYYY_MM stamp for this publication (default: current month).
@@ -53,60 +65,65 @@ publish_bmf_lookups <- function(lookups    = lookup_ls,
   out_dir <- file.path(lookup_dir, vintage)
   if (!dir.exists(out_dir)) dir.create(out_dir, recursive = TRUE)
 
-  # --- Write CSVs and build manifest entries ---------------------------------
-  manifest_entries <- vector("list", length(lookups))
-  names(manifest_entries) <- names(lookups)
-
+  # --- Write CSVs ------------------------------------------------------------
+  outputs <- vector("list", length(lookups))
+  names(outputs) <- names(lookups)
   for (nm in names(lookups)) {
     df <- lookups[[nm]]
     csv_path <- file.path(out_dir, paste0(nm, ".csv"))
     data.table::fwrite(df, csv_path)
-    manifest_entries[[nm]] <- list(
-      file     = paste0(nm, ".csv"),
-      rows     = as.integer(nrow(df)),
-      cols     = as.integer(ncol(df)),
-      columns  = as.list(names(df)),
-      sha256   = digest::digest(file = csv_path, algo = "sha256"),
-      bytes    = as.integer(file.size(csv_path))
-    )
+    outputs[[nm]] <- list(path = csv_path, row_count = nrow(df), columns = names(df))
   }
 
-  manifest <- list(
-    vintage      = vintage,
-    generated_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
-    source       = list(
-      workbook   = "data/lookup/bmf_code_lookup.xlsx",
-      extra_csv  = "data/lookup/ntee_legacy_5char_lookup.csv"
-    ),
-    files        = manifest_entries
+  # --- Build the contract-standard _manifest.json (ADR 0014) -----------------
+  inputs <- list(
+    manifest_input_repo("data/lookup/bmf_code_lookup.xlsx"),
+    manifest_input_repo("data/lookup/ntee_legacy_5char_lookup.csv")
   )
-  manifest_path <- file.path(out_dir, "MANIFEST.json")
-  jsonlite::write_json(manifest, manifest_path, pretty = TRUE, auto_unbox = TRUE)
+  mw <- write_manifest(vintage = vintage, out_dir = out_dir,
+                       outputs = outputs, inputs = inputs)
+  manifest      <- mw$manifest
+  manifest_path <- mw$path
 
-  message(sprintf("Wrote %d lookup CSVs + MANIFEST.json to %s",
+  # sha256 per output file, keyed by basename (as in manifest$files).
+  shas <- vapply(names(lookups),
+                 function(nm) manifest$files[[paste0(nm, ".csv")]]$sha256,
+                 character(1))
+  names(shas) <- paste0(names(lookups), ".csv")
+
+  message(sprintf("Wrote %d lookup CSVs + _manifest.json to %s",
                   length(lookups), out_dir))
 
-  # --- Fetch existing remote manifest for skip decisions ---------------------
+  # --- Skip-decision inputs --------------------------------------------------
   vintage_prefix <- paste0(s3_prefix, vintage, "/")
   latest_prefix  <- paste0(s3_prefix, "latest/")
-  remote_manifest <- .read_remote_manifest(
-    paste0(vintage_prefix, "MANIFEST.json"), bucket
+  remote_manifest <- read_existing_manifest(
+    paste0(vintage_prefix, "_manifest.json"), bucket
   )
 
   uploaded <- character()
   skipped  <- character()
 
+  # Dual-write the manifest during the ADR 0014 deprecation window:
+  # _manifest.json is canonical; MANIFEST.json is a byte-identical copy kept
+  # readable for one window for any consumer still on the old path.
+  put_manifest <- function(prefix) {
+    upload_to_s3(manifest_path, paste0(prefix, "_manifest.json"), bucket = bucket)
+    upload_to_s3(manifest_path, paste0(prefix, "MANIFEST.json"),  bucket = bucket)
+  }
+
   if (dry_run) {
     message("DRY RUN: would upload to s3://", bucket, "/", vintage_prefix)
     for (nm in names(lookups)) {
-      action <- if (.hash_unchanged(remote_manifest, nm, manifest_entries[[nm]]$sha256)) {
+      key <- paste0(nm, ".csv")
+      action <- if (manifest_unchanged(remote_manifest, key, shas[[key]])) {
         skipped  <- c(skipped, nm); "SKIP"
       } else {
         uploaded <- c(uploaded, nm); "PUT "
       }
-      message(sprintf("  %s %s%s.csv", action, vintage_prefix, nm))
+      message(sprintf("  %s %s%s", action, vintage_prefix, key))
     }
-    message(sprintf("  PUT  %sMANIFEST.json", vintage_prefix))
+    message(sprintf("  PUT  %s_manifest.json (+ MANIFEST.json copy)", vintage_prefix))
     message("DRY RUN: latest/ mirror would copy the same files.")
     return(invisible(list(manifest = manifest, vintage = vintage,
                           uploaded = uploaded, skipped = skipped)))
@@ -114,66 +131,37 @@ publish_bmf_lookups <- function(lookups    = lookup_ls,
 
   # --- Upload to vintage prefix ----------------------------------------------
   for (nm in names(lookups)) {
-    csv_local <- file.path(out_dir, paste0(nm, ".csv"))
-    csv_key   <- paste0(vintage_prefix, nm, ".csv")
-    if (.hash_unchanged(remote_manifest, nm, manifest_entries[[nm]]$sha256)) {
-      message(sprintf("SKIP (unchanged): s3://%s/%s", bucket, csv_key))
+    key       <- paste0(nm, ".csv")
+    csv_local <- file.path(out_dir, key)
+    if (manifest_unchanged(remote_manifest, key, shas[[key]])) {
+      message(sprintf("SKIP (unchanged): s3://%s/%s%s", bucket, vintage_prefix, key))
       skipped <- c(skipped, nm)
       next
     }
-    upload_to_s3(csv_local, csv_key, bucket = bucket)
+    upload_to_s3(csv_local, paste0(vintage_prefix, key), bucket = bucket)
     uploaded <- c(uploaded, nm)
   }
-  # Always refresh the manifest — it carries the generated_at timestamp.
-  upload_to_s3(manifest_path,
-               paste0(vintage_prefix, "MANIFEST.json"),
-               bucket = bucket)
+  put_manifest(vintage_prefix)  # always refresh — carries the built_at timestamp
 
   # --- Mirror to latest/ -----------------------------------------------------
-  # Compare against latest/MANIFEST.json so we only re-PUT files that
+  # Compare against latest/_manifest.json so we only re-PUT files that
   # actually changed relative to whatever "latest" currently points at.
-  remote_latest <- .read_remote_manifest(
-    paste0(latest_prefix, "MANIFEST.json"), bucket
+  remote_latest <- read_existing_manifest(
+    paste0(latest_prefix, "_manifest.json"), bucket
   )
   for (nm in names(lookups)) {
-    if (.hash_unchanged(remote_latest, nm, manifest_entries[[nm]]$sha256)) {
-      message(sprintf("SKIP latest (unchanged): %s%s.csv", latest_prefix, nm))
+    key <- paste0(nm, ".csv")
+    if (manifest_unchanged(remote_latest, key, shas[[key]])) {
+      message(sprintf("SKIP latest (unchanged): %s%s", latest_prefix, key))
       next
     }
-    csv_local <- file.path(out_dir, paste0(nm, ".csv"))
-    upload_to_s3(csv_local, paste0(latest_prefix, nm, ".csv"), bucket = bucket)
+    upload_to_s3(file.path(out_dir, key), paste0(latest_prefix, key), bucket = bucket)
   }
-  upload_to_s3(manifest_path,
-               paste0(latest_prefix, "MANIFEST.json"),
-               bucket = bucket)
+  put_manifest(latest_prefix)
 
   message(sprintf("Publish complete: %d uploaded, %d skipped (vintage=%s)",
                   length(uploaded), length(skipped), vintage))
 
   invisible(list(manifest = manifest, vintage = vintage,
                  uploaded = uploaded, skipped = skipped))
-}
-
-# Returns parsed manifest list or NULL if not present.
-.read_remote_manifest <- function(s3_key, bucket) {
-  exists <- tryCatch(
-    aws.s3::object_exists(object = s3_key, bucket = bucket),
-    error = function(e) FALSE
-  )
-  if (!isTRUE(exists)) return(NULL)
-  tryCatch({
-    raw <- aws.s3::get_object(object = s3_key, bucket = bucket)
-    jsonlite::fromJSON(rawToChar(raw), simplifyVector = FALSE)
-  }, error = function(e) {
-    message(sprintf("Could not read remote manifest s3://%s/%s: %s",
-                    bucket, s3_key, e$message))
-    NULL
-  })
-}
-
-.hash_unchanged <- function(remote_manifest, name, sha256) {
-  if (is.null(remote_manifest)) return(FALSE)
-  entry <- remote_manifest$files[[name]]
-  if (is.null(entry) || is.null(entry$sha256)) return(FALSE)
-  identical(entry$sha256, sha256)
 }

--- a/R/run_legacy_pipeline.R
+++ b/R/run_legacy_pipeline.R
@@ -54,6 +54,7 @@ library(data.table)
 # ============================================================================
 
 source(here::here("R", "config.R"))
+source(here::here("R", "manifest.R"))
 source(here::here("R", "input_validation.R"))
 source(here::here("R", "utils", "logging.R"))
 source(here::here("R", "utils", "transform_utils.R"))
@@ -352,6 +353,33 @@ if (ENABLE_S3_UPLOAD) {
     month = PROCESSING_MONTH,
     prefix = BMF_S3_LEGACY_PROCESSED_PREFIX
   )
+
+  # --- Contract-standard manifest (nccs-contracts ADR 0014) -----------------
+  # bmf-legacy is an append-only archive of historical dumps: one manifest
+  # per vintage, with NO latest/ mirror — consumers (master_bmf_builder.R)
+  # glob and stack all vintages. See contracts/bmf-legacy.yml and ADR 0013's
+  # legacy exemption. Emission follows the R/publish_lookups.R reference.
+  legacy_vintage <- sprintf("%s_%s", PROCESSING_YEAR, PROCESSING_MONTH)
+  mw_legacy <- write_manifest(
+    vintage = legacy_vintage,
+    out_dir = "data/processed",
+    outputs = list(
+      processed  = list(path = processed_path,
+                        row_count = nrow(bmf_processed),
+                        columns   = names(bmf_processed)),
+      dictionary = list(path = dictionary_path)
+    ),
+    inputs = list(
+      # Provenance: the read-only historical archive this vintage built from.
+      # TODO: thread the exact source object key + S3 ETag here.
+      list(uri = paste0("s3://", BMF_S3_BUCKET, "/", BMF_S3_LEGACY_PREFIX))
+    )
+  )
+  legacy_manifest_key <- sprintf("%s%s/_manifest.json",
+                                 BMF_S3_LEGACY_PROCESSED_PREFIX, legacy_vintage)
+  upload_to_s3(mw_legacy$path, legacy_manifest_key, bucket = BMF_S3_BUCKET)
+  log_info(sprintf("Uploaded legacy _manifest.json to s3://%s/%s",
+                   BMF_S3_BUCKET, legacy_manifest_key))
 }
 
 # ============================================================================

--- a/R/run_master_pipeline.R
+++ b/R/run_master_pipeline.R
@@ -70,6 +70,7 @@ source(here::here("R", "utils", "logging.R"))
 source(here::here("R", "quality", "post_checks.R"))            # generate_data_dictionary()
 source(here::here("R", "master_bmf_builder.R"))
 source(here::here("R", "quality", "master_post_checks.R"))
+source(here::here("R", "manifest.R"))
 source(here::here("R", "publish_lookups.R"))
 
 # ============================================================================

--- a/R/run_publish_lookups.R
+++ b/R/run_publish_lookups.R
@@ -18,6 +18,7 @@ if (!exists("PUBLISH_VINTAGE")) PUBLISH_VINTAGE <- format(Sys.Date(), "%Y_%m")
 
 source(here::here("R", "config.R"))
 source(here::here("R", "utils", "logging.R"))
+source(here::here("R", "manifest.R"))
 source(here::here("R", "publish_lookups.R"))
 
 log_phase_start("PUBLISH LOOKUPS")


### PR DESCRIPTION
Establishes the **reference implementation** of the contract-standard `_manifest.json` (nccs-contracts ADR 0014) and applies it to `bmf-lookups` and `bmf-legacy`. The remaining producers (`bmf-master`, `bmf-master-geocoded`) are intended to be migrated by replicating this reference.

## What
- **`R/manifest.R`** (new) — shared helper: `write_manifest()` emits the ADR 0014 shape (`vintage`, `built_at` UTC `Z`, `git_sha`, `inputs[]`, `files{basename:{sha256,bytes,row_count,columns}}`); plus `git_short_sha()`, `manifest_input_repo()`, `read_existing_manifest()`, `manifest_unchanged()`.
- **`R/publish_lookups.R`** — migrated from the old `MANIFEST.json` shape to `_manifest.json` via the helper. Dual-writes `MANIFEST.json` (byte-identical) for one ADR 0014 deprecation window.
- **`R/run_legacy_pipeline.R`** — emits a standard `_manifest.json` per legacy vintage. **No `latest/` mirror** — `bmf-legacy` is an append-only archive consumers glob-stack (ADR 0013 legacy exemption + the contract).
- Wired `R/manifest.R` into the run-script loaders.

## Deliberately out of scope
- The **ADR 0013 vintage-format flip** (`YYYY_MM` → `v{YYYY.MM}`) — a breaking path change for a separate, consumer-coordinated migration. This PR is **manifest-shape only**.
- `bmf-master` / `bmf-master-geocoded` — left for the Copilot agent to replicate from this reference.

## Verification
- All edited files parse cleanly (`Rscript parse`).
- `write_manifest()` exercised in isolation → emits the exact ADR 0014 shape (top-level keys, UTC `Z`, basename-keyed files, `row_count`/`columns`, no stray `cols`, filename `_manifest.json`).
- **Not yet run end-to-end against S3** — please run `run_publish_lookups.R` (dry-run first) before merge. The new manifest lands on S3 at the next publish; during the deprecation window both `MANIFEST.json` and `_manifest.json` are written.

## Follow-ups (tracked for reconcile in nccs-contracts)
- `bmf-legacy` manifest `inputs[]` records the source archive *prefix* only; threading the exact source object key + S3 ETag is a `TODO` in the code.
- After merge + publish: reconcile `bmf-lookups.yml` / `bmf-legacy.yml` `manifest.path`, flip ADR 0013/0014 status, update `ARCHITECTURE.md` §3 (`MANIFEST.json` → `_manifest.json`).

Part of executing ADR 0013/0014; ADR 0013 amended (legacy `latest/` exemption) in nccs-contracts.