### PR TITLE
docs(state-marts): note count divergence from sector-in-brief

### DIFF
--- a/docs/12-state-marts.qmd
+++ b/docs/12-state-marts.qmd
@@ -84,3 +84,13 @@ of the geocoded master; they have no other inputs.
   @sec-master-bmf for the recommended cast list.
 - **No schema changes.** The marts contain the exact same columns as
   the geocoded master plus the `state` partition column.
+- **Counts won't match sector-in-brief.** A nonprofit count from these
+  marts (filtering `last_year_in_bmf`, partitioned on the mailing-state
+  key `org_addr_state`) runs slightly below the `sector-in-brief`
+  `number_nonprofits` figure for the same place/year. That product
+  counts by an active-window rule (`org_year_first ≤ Y ≤ org_year_last`)
+  and by geocoded county/state — both by design, not a data error. For
+  "how many active nonprofits in place X," cite sector-in-brief; query
+  these marts directly only for EIN-level detail. See the "Counting
+  semantics" note in the `nccs-contracts` `sector-in-brief.yml` /
+  `bmf-master-geocoded.yml` contracts for the rule and a worked example.


### PR DESCRIPTION
## What

Adds a Caveats bullet to `docs/12-state-marts.qmd` documenting why nonprofit
counts pulled directly from the state marts run slightly below
sector-in-brief's `number_nonprofits` for the same place/year.

## Why

Two by-design differences, **not** a data error:

1. **Active-window vs vintage presence.** sector-in-brief counts an EIN in
   year Y when `org_year_first ≤ Y ≤ org_year_last`; a direct mart query keys
   off `last_year_in_bmf` (last vintage observed).
2. **Geocoded vs mailing geography.** sector-in-brief places orgs by geocoded
   `Census County`/`Census State`; the marts partition on the mailing-state
   key `org_addr_state`.

Worked example (2026, 501(c)(3), 7 SE-Michigan counties): direct master query
= 21,586 (mailing-state partition) / 21,589 (geocoded geography);
`number_nonprofits` = 21,638. Δ52 = 3 (geography) + 49 (active-window).
Private-foundation counts matched to the org, localizing the gap to these two
definitions.

The canonical "Counting semantics" note lives in the `nccs-contracts`
`sector-in-brief.yml` / `bmf-master-geocoded.yml` contracts (handled
separately); this is the discoverable pointer for BMF/state-mart users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)