### PR TITLE
docs(crosswalk): correct CBSA count (932, not 935)

### DIFF
--- a/docs/14-cbsa-crosswalk.qmd
+++ b/docs/14-cbsa-crosswalk.qmd
@@ -74,7 +74,7 @@ Of the **3,224** resolved county GEOIDs in the county crosswalk:
 |--------------------------------|----------|-------|
 | Metropolitan Statistical Area  | 1,250    |       |
 | Micropolitan Statistical Area  |   661    |       |
-| **In a CBSA**                  | **1,911**| 935   |
+| **In a CBSA**                  | **1,911**| 932   |
 | Rural (no CBSA)                | 1,313    | —     |
 
 `cbsa_crosswalk_audit.csv` records the rural tally plus the handful of

--- a/scripts/build_cbsa_crosswalk.R
+++ b/scripts/build_cbsa_crosswalk.R
@@ -91,8 +91,9 @@ n_cbsa  <- sum(!is.na(xwalk$cbsa_code))
 n_rural <- sum(is.na(xwalk$cbsa_code))
 n_metro <- sum(xwalk$cbsa_type == "Metropolitan Statistical Area", na.rm = TRUE)
 n_micro <- sum(xwalk$cbsa_type == "Micropolitan Statistical Area", na.rm = TRUE)
-message(sprintf("      %d in a CBSA (%d metro, %d micro) | %d rural (no CBSA)",
-                n_cbsa, n_metro, n_micro, n_rural))
+message(sprintf("      %d in a CBSA (%d metro, %d micro) across %d distinct CBSAs | %d rural (no CBSA)",
+                n_cbsa, n_metro, n_micro,
+                dplyr::n_distinct(xwalk$cbsa_code[!is.na(xwalk$cbsa_code)]), n_rural))
 
 # Invariants
 stopifnot(


### PR DESCRIPTION
Small accuracy fix on top of #16.

The CBSA crosswalk doc (`docs/14-cbsa-crosswalk.qmd`) reported **935** distinct CBSAs, which was the count in the full OMB delineation. Only **932** of those have a county in the BMF universe (the difference is CT CBSAs whose only counties are the unresolved planning-region labels). Verified against the published artifact:

```
distinct non-NA cbsa_code in cbsa_crosswalk.parquet = 932
```

Also updates the build summary in `scripts/build_cbsa_crosswalk.R` to report distinct-CBSAs-**in-output** rather than the delineation total, so the figure stays correct on rebuild.

No artifact change — the published parquet/csv on S3 were always 932; only the doc prose was off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)