### PR TITLE
ci(contracts-guard): add reusable-workflow caller (ADR 0022)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,6 +355,18 @@ Some artifacts in this repo are part of a stable contract with downstream
 consumers. Treat their S3 paths as a public API: do not rename, do not move,
 and re-publish whenever the local source changes.
 
+**Contract-change guard (ADR 0022).** A PR that touches what/where this repo
+publishes — or the schema/manifest shape — must acknowledge the
+[`nccs-contracts`](https://github.com/UrbanInstitute/nccs-contracts) impact, or
+CI fails. The `.github/workflows/contracts-guard.yml` caller (a thin wrapper over
+the reusable guard in `nccs-contracts`) fires on PRs that change
+`R/publish_*.R`, `R/run_*.R`, `R/master_*.R`, `R/config.R`, `R/manifest.R`, or
+`scripts/build_*.R`. To pass: add an `ADR NNNN` breadcrumb to a commit message
+or the PR body and queue the `nccs-contracts` reconcile, **or** add the
+`contracts-ack` label if there is genuinely no contract impact. The guard checks
+*acknowledgment, not correctness*. Keep the caller's `paths_regex` in sync with
+`nccs-contracts/scripts/reconcile.sh`. See `nccs-contracts/CONTRIBUTING.md`.
+
 ### Geography crosswalks → S3
 
 Path contract (each prefix holds `*.parquet` + `*.csv` + ADR 0014 `_manifest.json`):


### PR DESCRIPTION
## What

Replace the standalone contracts-guard draft with a **thin caller** of the reusable workflow now living in `nccs-contracts` (`.github/workflows/contracts-guard.yml@main`, nccs-contracts PR #8). This is **ADR 0022 step 2** (convert the drafted standalone guard → caller) plus the bmf slice of **step 5** (CLAUDE.md pointer).

## Details

- **`.github/workflows/contracts-guard.yml`** — ~20-line caller passing only this repo's `paths_regex`. Guard logic lives once in `nccs-contracts`; improvements there propagate here for free (no copy-drift).
- **`CLAUDE.md`** — documents the convention under "Published artifacts" so contributors/agents know a contract-relevant PR needs an `ADR NNNN` breadcrumb or the `contracts-ack` label.
- `paths_regex` is byte-for-byte in sync with `nccs-contracts/scripts/reconcile.sh::paths_regex_for(nccs-data-bmf)`.

## Notes

- The guard verifies **acknowledgment, not correctness** (semantic Loop-3 review is the deferred follow-on per ADR 0022 §7).
- This PR's own changed paths (`.github/workflows/*`, `CLAUDE.md`) do **not** match `paths_regex`, so the guard does not gate its own introduction — no chicken-and-egg.
- Caller pins `@main`; the reusable workflow is already merged to `nccs-contracts` main.

Refs: ADR 0022

🤖 Generated with [Claude Code](https://claude.com/claude-code)