### PR TITLE
fix(ntee): correct 4-char cleaning so nteev2_subsector UNI holds real universities (ADR 0032)

### DIFF
--- a/R/transform_ntee_code.R
+++ b/R/transform_ntee_code.R
@@ -17,7 +17,7 @@ NTEE_MAJOR_GROUP_LOOKUP_COLS <- c("ntee_code_first_character", "ntee_code_major_
 NTEE_COMMON_CODE_LOOKUP_COLS <- c("ntee_common_code", "ntee_common_code_definition")
 
 # Helper column names (dot prefix for internal use)
-HELPER_COLUMNS <- c(".len", ".first", ".last", ".int23", ".char23")
+HELPER_COLUMNS <- c(".len", ".first", ".last", ".char23")
 
 # Columns to set to UNDEFINED when NTEE code is invalid
 COLS_TO_FIX <- c("naics_code", "ntee_code_major_group", "ntee_code_definition")
@@ -215,22 +215,23 @@ transform_ntee_code <- function(
     .first = substr(ntee_code_raw, 1, 1),
     .char23 = substr(ntee_code_raw, 2, 3)
   )]
-  dt[, `:=`(
-    .last = substr(ntee_code_raw, .len, .len),
-    .int23 = suppressWarnings(as.integer(.char23))
-  )]
+  dt[, .last := substr(ntee_code_raw, .len, .len)]
 
   # ---------------------------------------------------------------------------
   # NTEE Code Standardization
   # ---------------------------------------------------------------------------
+  # A 4-char raw code is [letter][2-digit subgroup][trailing modifier], so the
+  # canonical 3-char NTEE-CC code is always substr(1, 3) regardless of whether
+  # the modifier is a letter or a digit. (ADR 0032: the prior digit-modifier
+  # branch did paste0(.first, .last, "0"), which discarded the subgroup —
+  # e.g. "B430" -> "B00" -> INVALID, wrongly killing valid university codes.)
   dt[, ntee_code_clean := data.table::fcase(
     .len == 0,                          NTEE_UNDEFINED,
     !grepl("[A-Z]", .first),            NTEE_INVALID,
     .len == 1,                          paste0(ntee_code_raw, "00"),
     .len == 2,                          paste0(ntee_code_raw, "0"),
     .len == 3,                          ntee_code_raw,
-    .len == 4 & grepl("[A-Z]", .last),  substr(ntee_code_raw, 1, 3),
-    .len == 4 & grepl("[0-9]", .last),  paste0(.first, .last, "0"),
+    .len == 4,                          substr(ntee_code_raw, 1, 3),
     default = NTEE_INVALID
   )]
 
@@ -345,17 +346,29 @@ transform_ntee_code <- function(
 }
 
 .nteev2_code_transform <- function(dt) {
-  # NTEEV2 Code
+  # NTEEV2 Code — the middle component is the cleaned, lookup-validated
+  # NTEE-CC code (e.g. "B43"); "Z99" only when the code is invalid or
+  # undefined. (ADR 0032: the prior formula keyed off raw char positions
+  # and collapsed ~69% of records to "Z99".) Legacy 5-char rows are
+  # re-derived in .apply_legacy_5char_crosswalk, which overrides .len == 5.
   dt[, nteev2_code := data.table::fcase(
-    .len == 3 & .int23 <= 19, paste0(.first, "00"),
-    .len == 4 & .int23 <= 19, paste0(.first, .last, "0"),
-    default = "Z99"
+    ntee_code_clean %chin% c(NTEE_INVALID, NTEE_UNDEFINED), "Z99",
+    default = ntee_code_clean
   )]
 
-  # NTEEV2 Subsector
+  # NTEEV2 Subsector — University/Hospital keyed off the cleaned NTEE-CC
+  # code so the B40-B43/B50 and E20-E24 sets are reachable. (ADR 0032: the
+  # prior code keyed off nteev2_code, which could never emit B41/B42/B43,
+  # so no real university ever reached "UNI".)
+  #
+  # Invalid/undefined codes resolve to "UNU" (Unknown): if we could not
+  # validate a code, we must not infer a real subsector from the raw first
+  # letter. (ADR 0032 Decision 4 — the correct policy; the prior fall-through
+  # to the .first cases mislabeled ~12.7k unvalidated rows as EDU/HMS/etc.)
   dt[, nteev2_subsector := data.table::fcase(
-    nteev2_code %chin% NTEEV2_SUBSECTOR_UNIVERSITY, "UNI",
-    nteev2_code %chin% NTEEV2_SUBSECTOR_HOSPITAL,   "HOS",
+    ntee_code_clean %chin% NTEEV2_SUBSECTOR_UNIVERSITY,      "UNI",
+    ntee_code_clean %chin% NTEEV2_SUBSECTOR_HOSPITAL,        "HOS",
+    ntee_code_clean %chin% c(NTEE_INVALID, NTEE_UNDEFINED),  "UNU",
     .first == "A",                                   "ART",
     .first == "B",                                   "EDU",
     .first %chin% c("C", "D"),                       "ENV",

--- a/scripts/check_ntee_university_coverage.R
+++ b/scripts/check_ntee_university_coverage.R
@@ -1,0 +1,77 @@
+# ============================================================================
+# check_ntee_university_coverage.R
+#
+# Regression guard for the NTEE cleaner / nteev2 fix (ADR 0032). Confirms that
+# valid university (B40-B43, B50) and hospital (E20-E24) NTEE codes survive
+# cleaning and reach the UNI / HOS subsectors instead of being mangled to
+# INVALID and collapsing into EDU / HEL.
+#
+# Background: a 4-char raw code is [letter][2-digit subgroup][trailing modifier].
+# The old digit-modifier branch did paste0(.first, .last, "0"), discarding the
+# subgroup ("B430" -> "B00" -> INVALID), and the subsector keyed off a parallel
+# nteev2_code formula that could never emit B41/B42/B43 -- so no real university
+# ever reached "UNI". See R/transform_ntee_code.R and nccs-contracts ADR 0032.
+#
+# Usage (from project root):
+#   Rscript scripts/check_ntee_university_coverage.R
+#
+# Exits non-zero if any assertion fails.
+# ============================================================================
+suppressPackageStartupMessages({
+  library(data.table)
+  library(openxlsx)
+})
+
+wb <- "data/lookup/bmf_code_lookup.xlsx"
+if (!file.exists(wb)) stop("Lookup workbook not found at: ", wb)
+
+lookup_ls <- list(
+  ntee_code             = as.data.table(read.xlsx(wb, sheet = "ntee_code")),
+  ntee_code_major_group = as.data.table(read.xlsx(wb, sheet = "ntee_code_major_group")),
+  ntee_common_code      = as.data.table(read.xlsx(wb, sheet = "ntee_common_code")),
+  nteev2_subsector      = as.data.table(read.xlsx(wb, sheet = "nteev2_subsector"))
+)
+PROCESSING_YEAR <- "2025"
+source("R/transform_ntee_code.R")
+
+# Canonical fixtures: raw NTEE_CD -> expected (clean, subsector, composite).
+# Covers 4-char trailing-zero, 3-char, 4-char trailing-letter, hospital, and
+# the genuine-upstream-gap (null) case.
+# "QZZ" guards the INVALID->UNU policy (ADR 0032 Decision 4): it is unvalidated
+# (not in the lookup) but its first letter "Q" would map to IFA under the old
+# first-letter fall-through. The null row likewise must land UNU, not a sector.
+fixtures <- data.table(
+  ein      = sprintf("00-%07d", seq_len(8)),
+  NTEE_CD  = c("B430",  "B43",  "B420",  "B500",  "E220",  "B05",  "QZZ",     NA_character_),
+  exp_clean= c("B43",   "B43",  "B42",   "B50",   "E22",   "B05",  "INVALID", "INVALID"),
+  exp_sub  = c("UNI",   "UNI",  "UNI",   "UNI",   "HOS",   "EDU",  "UNU",     "UNU")
+)
+
+out <- suppressWarnings(suppressMessages(
+  transform_ntee_code(fixtures[, .(ein, NTEE_CD)], input_ntee_col = "NTEE_CD",
+                      year = "2025", write_scd = FALSE)
+))
+res <- merge(fixtures, out[, .(ein, ntee_code_raw, ntee_code_clean, nteev2_subsector, nteev2)],
+             by = "ein", sort = FALSE)
+res[, ok := ntee_code_clean == exp_clean & nteev2_subsector == exp_sub]
+
+cat("--- NTEE university/hospital coverage check (ADR 0032) ---\n")
+print(res[, .(NTEE_CD, ntee_code_clean, exp_clean, nteev2_subsector, exp_sub, nteev2, ok)])
+
+failures <- res[ok == FALSE]
+if (nrow(failures) > 0) {
+  stop(sprintf("FAIL: %d fixture(s) did not match expected clean/subsector.",
+               nrow(failures)))
+}
+
+# Invariant: the university/hospital subsector constants must be reachable,
+# i.e. every code in them is a valid lookup code (a clean 3-char code can equal
+# it). Guards against a future edit that keys subsector off a derived value.
+valid <- lookup_ls$ntee_code$ntee_code
+unreachable <- setdiff(c(NTEEV2_SUBSECTOR_UNIVERSITY, NTEEV2_SUBSECTOR_HOSPITAL), valid)
+if (length(unreachable) > 0) {
+  stop("FAIL: subsector codes absent from ntee_code lookup (unreachable): ",
+       paste(unreachable, collapse = ", "))
+}
+
+cat("\nPASS: all fixtures matched; UNI/HOS code sets are reachable.\n")

--- a/scripts/measure_ntee_fix_blast_radius.R
+++ b/scripts/measure_ntee_fix_blast_radius.R
@@ -1,0 +1,146 @@
+# Blast-radius measurement for the NTEE cleaner / nteev2 fix (ADR 0032).
+# Reproduces CURRENT transform logic vs PROPOSED over the full current BMF.
+# Read-only; no S3, no writes except a small summary to data/quality/.
+
+suppressMessages({library(data.table); library(openxlsx)})
+
+BMF <- "data/raw/bmf/2026-06-BMF.csv"
+wb  <- "data/lookup/bmf_code_lookup.xlsx"
+
+ntee_code_lookup <- as.data.table(read.xlsx(wb, sheet = "ntee_code"))
+valid_lookup     <- ntee_code_lookup$ntee_code
+INVALID <- "INVALID"; UNDEF <- "UNDEFINED"
+valid_set <- c(INVALID, UNDEF, valid_lookup)
+
+UNIV <- c("B40","B41","B42","B43","B50")
+HOSP <- c("E20","E21","E22","E24")
+
+dt <- fread(BMF, select = "NTEE_CD", colClasses = "character",
+            showProgress = FALSE)
+setnames(dt, "NTEE_CD", "raw0")
+dt[, ntee_code_raw := toupper(trimws(as.character(raw0)))]
+dt[is.na(ntee_code_raw), ntee_code_raw := ""]
+
+dt[, `:=`(.len = nchar(ntee_code_raw),
+          .first = substr(ntee_code_raw, 1, 1),
+          .char23 = substr(ntee_code_raw, 2, 3))]
+dt[, `:=`(.last = substr(ntee_code_raw, .len, .len),
+          .int23 = suppressWarnings(as.integer(.char23)))]
+
+# ---------------- CURRENT clean ----------------
+dt[, clean_cur := fcase(
+  .len == 0,                          UNDEF,
+  !grepl("[A-Z]", .first),            INVALID,
+  .len == 1,                          paste0(ntee_code_raw, "00"),
+  .len == 2,                          paste0(ntee_code_raw, "0"),
+  .len == 3,                          ntee_code_raw,
+  .len == 4 & grepl("[A-Z]", .last),  substr(ntee_code_raw, 1, 3),
+  .len == 4 & grepl("[0-9]", .last),  paste0(.first, .last, "0"),
+  default = INVALID)]
+dt[!clean_cur %chin% valid_set, clean_cur := INVALID]
+
+# ---------------- PROPOSED clean (both .len==4 -> substr(1,3)) ----------------
+dt[, clean_new := fcase(
+  .len == 0,                          UNDEF,
+  !grepl("[A-Z]", .first),            INVALID,
+  .len == 1,                          paste0(ntee_code_raw, "00"),
+  .len == 2,                          paste0(ntee_code_raw, "0"),
+  .len == 3,                          ntee_code_raw,
+  .len == 4,                          substr(ntee_code_raw, 1, 3),
+  default = INVALID)]
+dt[!clean_new %chin% valid_set, clean_new := INVALID]
+
+# ---------------- CURRENT nteev2_code + subsector ----------------
+dt[, code_cur := fcase(
+  .len == 3 & .int23 <= 19, paste0(.first, "00"),
+  .len == 4 & .int23 <= 19, paste0(.first, .last, "0"),
+  default = "Z99")]
+sub_fcase <- function(code, first) {
+  fcase(
+    code %chin% UNIV, "UNI",
+    code %chin% HOSP, "HOS",
+    first == "A", "ART",
+    first == "B", "EDU",
+    first %chin% c("C","D"), "ENV",
+    first %chin% c("E","F","G","H"), "HEL",
+    first %chin% LETTERS[9:16], "HMS",
+    first == "Q", "IFA",
+    first %chin% c("R","S","T","U","V","W"), "PSB",
+    first == "X", "REL",
+    first == "Y", "MMB",
+    first == "Z", "UNU",
+    default = "UNU")
+}
+dt[, sub_cur := sub_fcase(code_cur, .first)]
+
+# ---------------- PROPOSED ----------------
+# Step 2 (subsector keys off cleaned code). first-letter from cleaned code when
+# valid, else from raw (so INVALID keeps current .first fallback for apples-to-
+# apples; the invalid->UNU policy is reported separately below).
+dt[, first_new := fifelse(clean_new %chin% c(INVALID, UNDEF), .first,
+                          substr(clean_new, 1, 1))]
+dt[, sub_new := sub_fcase(clean_new, first_new)]
+
+# Broader nteev2_code rebuild: middle component = cleaned NTEE-CC code, Z99 if
+# not a valid 3-char code.
+dt[, code_new := fifelse(clean_new %chin% c(INVALID, UNDEF), "Z99", clean_new)]
+
+# Variant: invalid/undefined -> UNU subsector (the "more correct" policy).
+dt[, sub_new_unu := fifelse(clean_new %chin% c(INVALID, UNDEF), "UNU", sub_new)]
+
+N <- nrow(dt)
+cat(sprintf("\n==== NTEE fix blast radius — %s rows (2026-06 BMF) ====\n\n", format(N, big.mark=",")))
+
+cat("--- (A) raw NTEE_CD nchar distribution ---\n"); print(table(dt$.len))
+
+cat("\n--- (B) 4-char rows: top chars2-3 x char4 patterns ---\n")
+b <- dt[.len == 4, .N, by = .(char23 = .char23, char4 = .last)][order(-N)]
+print(head(b, 15))
+cat(sprintf("4-char rows where char4=='0': %s of %s\n",
+            format(dt[.len==4 & .last=="0", .N], big.mark=","),
+            format(dt[.len==4, .N], big.mark=",")))
+cat(sprintf("4-char rows where chars2-3 are common-code (<=19): %s\n",
+            format(dt[.len==4 & .int23 <= 19, .N], big.mark=",")))
+
+cat("\n--- (C) clean: CURRENT vs PROPOSED ---\n")
+status <- function(x) fifelse(x==INVALID,"INVALID",fifelse(x==UNDEF,"UNDEFINED","valid"))
+dt[, scur := status(clean_cur)][, snew := status(clean_new)]
+print(dcast(dt[, .N, by=.(scur, snew)], scur ~ snew, value.var="N", fill=0))
+cat(sprintf("recovered INVALID->valid: %s   regressed valid->INVALID: %s\n",
+            format(dt[scur=="INVALID" & snew=="valid", .N], big.mark=","),
+            format(dt[scur=="valid" & snew=="INVALID", .N], big.mark=",")))
+cat("\nTop raw codes recovered (INVALID->valid):\n")
+print(head(dt[scur=="INVALID" & snew=="valid", .N, by=.(ntee_code_raw, clean_new)][order(-N)], 15))
+if (dt[scur=="valid" & snew=="INVALID", .N] > 0) {
+  cat("\nTop raw codes regressed (valid->INVALID):\n")
+  print(head(dt[scur=="valid" & snew=="INVALID", .N, by=.(ntee_code_raw, clean_cur)][order(-N)], 15))
+}
+
+cat("\n--- (D) nteev2_subsector: CURRENT vs PROPOSED (step-2, invalid keeps .first) ---\n")
+print(dt[sub_cur != sub_new, .N, by=.(sub_cur, sub_new)][order(-N)])
+cat(sprintf("\nUNI count  current: %s   proposed: %s\n",
+            format(dt[sub_cur=="UNI",.N], big.mark=","), format(dt[sub_new=="UNI",.N], big.mark=",")))
+cat(sprintf("HOS count  current: %s   proposed: %s\n",
+            format(dt[sub_cur=="HOS",.N], big.mark=","), format(dt[sub_new=="HOS",.N], big.mark=",")))
+
+cat("\n--- (E) university codes (clean_new in B40-B43,B50) ---\n")
+cat(sprintf("orgs with proposed clean in university set: %s\n",
+            format(dt[clean_new %chin% UNIV, .N], big.mark=",")))
+cat("their CURRENT subsector:\n"); print(dt[clean_new %chin% UNIV, .N, by=sub_cur][order(-N)])
+cat("their PROPOSED subsector:\n"); print(dt[clean_new %chin% UNIV, .N, by=sub_new][order(-N)])
+cat("\nhospital codes (clean_new in E20-E24): "); cat(format(dt[clean_new %chin% HOSP,.N], big.mark=","), "\n")
+cat("their CURRENT subsector:\n"); print(dt[clean_new %chin% HOSP, .N, by=sub_cur][order(-N)])
+
+cat("\n--- (F) nteev2_code rebuild blast radius ---\n")
+cat(sprintf("rows where code_new != code_cur: %s (%.1f%%)\n",
+            format(dt[code_new != code_cur, .N], big.mark=","),
+            100*dt[code_new != code_cur, .N]/N))
+cat("top transitions:\n")
+print(head(dt[code_new != code_cur, .N, by=.(code_cur, code_new)][order(-N)], 12))
+
+cat("\n--- (G) invalid->UNU policy effect (informational) ---\n")
+cat(sprintf("rows currently INVALID/UNDEF that get a non-UNU subsector today: %s\n",
+            format(dt[clean_new %chin% c(INVALID,UNDEF) & sub_cur != "UNU", .N], big.mark=",")))
+print(head(dt[clean_new %chin% c(INVALID,UNDEF) & sub_cur != "UNU", .N, by=sub_cur][order(-N)], 12))
+
+cat("\n==== done ====\n")


### PR DESCRIPTION
Implements **ADR 0032** (nccs-contracts #36). A consumer investigation (PA universities, CMU missing) traced to two stacked defects in `R/transform_ntee_code.R`, plus an adopted policy fix.

## Changes
1. **Clean-code:** both `.len==4` branches → `substr(1,3)`. The digit-suffix branch did `paste0(.first,.last,"0")`, mangling `B430→B00→INVALID` and discarding the subgroup.
2. **`nteev2_code` rebuild:** middle component = cleaned, lookup-validated NTEE-CC code; `Z99` only when invalid/undefined. Deletes the dead `.int23` formula (single source of truth).
3. **Subsector reachability:** `UNI`/`HOS` key off `ntee_code_clean` (the old code keyed off `nteev2_code`, which could never emit `B41/B42/B43` — so no real university ever reached `UNI`).
4. **INVALID/UNDEFINED → `UNU`** (ADR 0032 Decision 4): unvalidated codes no longer inherit a subsector from the raw first letter.

## Blast radius — measured over the full 2026-06 BMF (1,966,267 rows)
| metric | before | after |
|---|---|---|
| `UNI` | 603 (all junk) | **3,589** (genuine `B40–B43,B50`) |
| `HOS` | 525 | **5,621** |
| `nteev2_code == Z99` | 69.4% | 30.7% |
| `INVALID→valid` recovered | — | +39,390 |
| `INVALID→UNU` | — | +12,667 |

Of 3,589 orgs with a real university code, **0 reached `UNI` before**.

## Tests
- `scripts/check_ntee_university_coverage.R` — regression guard (university/hospital/INVALID→UNU fixtures + reachability invariants). **Passing.**
- `scripts/measure_ntee_fix_blast_radius.R` — reproducible read-only measurement (source of the numbers above).

## Contract note (ADR 0022)
Touches `R/transform_*`; the contracts-guard caller fires. Acknowledged via **ADR 0032** (breadcrumb in the commit). Republish overwrites `latest` in place (immediate cutover — old `UNI`/`EDU` values are wrong, not a contract worth a window; see ADR 0032 Deprecation-window decision). Master rebuild + republish tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)