### PR TITLE
fix: recover legacy street addresses (ADDRESS -> STREET) + crosswalk guardrail

### DIFF
--- a/R/legacy_bmf_adapter.R
+++ b/R/legacy_bmf_adapter.R
@@ -91,6 +91,25 @@ load_crosswalk_v2 <- function(path = here::here("data", "crosswalks", "XWALK-BMF
     ))
   }
 
+  # Guardrail (issue #29): a legacy column that aliases a current-schema
+  # concept must be renamed to it, never dropped. The one drop+alias row we
+  # ever had (ADDRESS, "redundant with STREET") silently destroyed the only
+  # street source in 58 vintages, because no legacy file actually has a
+  # STREET column. A genuine within-file duplicate needs its own
+  # subcategory with a machine-checkable target, not "alias".
+  if ("subcategory" %in% names(xw)) {
+    bad <- xw[disposition == "drop" & subcategory == "alias"]
+    if (nrow(bad) > 0) {
+      log_error(sprintf(
+        paste0("Crosswalk has %d drop+alias row(s): %s. An alias of a ",
+               "current-schema column must use disposition 'rename' (see ",
+               "issue #29 — dropping ADDRESS as 'redundant with STREET' ",
+               "silently lost all legacy street data)."),
+        nrow(bad), paste(bad$legacy_name_upper, collapse = ", ")
+      ))
+    }
+  }
+
   data.table::setkey(xw, legacy_name_upper)
   xw
 }

--- a/R/run_legacy_pipeline.R
+++ b/R/run_legacy_pipeline.R
@@ -26,10 +26,15 @@
 # Pipeline Configuration
 # ============================================================================
 
-ENABLE_CHECKPOINTS <- TRUE
-CHECKPOINT_DIR <- "data/checkpoints"
-STRICT_QUALITY_GATES <- TRUE
-ENABLE_S3_UPLOAD <- TRUE  # Uploads to s3://nccsdata/{intermediate,processed}/bmf-legacy/YYYY_MM/
+# Control flags. exists()-guarded so callers can pre-set them before
+# source(), same as the LEGACY_BMF_* source configuration below. Previously
+# ENABLE_S3_UPLOAD was assigned unconditionally, which clobbered a caller's
+# ENABLE_S3_UPLOAD <- FALSE and let a local validation run attempt writes to
+# the production S3 prefixes (issue #29 validation, 2026-07-24).
+if (!exists("ENABLE_CHECKPOINTS"))     ENABLE_CHECKPOINTS <- TRUE
+if (!exists("CHECKPOINT_DIR"))         CHECKPOINT_DIR <- "data/checkpoints"
+if (!exists("STRICT_QUALITY_GATES"))   STRICT_QUALITY_GATES <- TRUE
+if (!exists("ENABLE_S3_UPLOAD"))       ENABLE_S3_UPLOAD <- TRUE  # Uploads to s3://nccsdata/{intermediate,processed}/bmf-legacy/YYYY_MM/
 
 # Legacy source configuration - set before sourcing to override defaults.
 #   LEGACY_BMF_FILE  : explicit local path (skips S3 download)
@@ -377,9 +382,15 @@ if (ENABLE_S3_UPLOAD) {
   )
   legacy_manifest_key <- sprintf("%s%s/_manifest.json",
                                  BMF_S3_LEGACY_PROCESSED_PREFIX, legacy_vintage)
-  upload_to_s3(mw_legacy$path, legacy_manifest_key, bucket = BMF_S3_BUCKET)
-  log_info(sprintf("Uploaded legacy _manifest.json to s3://%s/%s",
-                   BMF_S3_BUCKET, legacy_manifest_key))
+  manifest_uploaded <- upload_to_s3(mw_legacy$path, legacy_manifest_key,
+                                    bucket = BMF_S3_BUCKET)
+  if (isTRUE(manifest_uploaded)) {
+    log_info(sprintf("Uploaded legacy _manifest.json to s3://%s/%s",
+                     BMF_S3_BUCKET, legacy_manifest_key))
+  } else {
+    log_error(sprintf("Legacy _manifest.json upload FAILED for s3://%s/%s",
+                      BMF_S3_BUCKET, legacy_manifest_key))
+  }
 }
 
 # ============================================================================

--- a/data/crosswalks/XWALK-BMF-V2.0.csv
+++ b/data/crosswalks/XWALK-BMF-V2.0.csv
@@ -59,7 +59,7 @@ NAICS,NAICS,,drop,other,73,1989-06,2016-08,NAICS,Character,6,NAICS Code,NAICS co
 ORGTYPCD,ORGTYPCD,,drop,single-year,1,1989-06,1989-06,Org. type,Character,3,"Org.type (F=private foundation, C=charity, T=trust, O=other exempt org.)",Organization type code (1989-only); not propagated to later dictionaries
 V_ERRORCD,v_errorCd,,drop,single-year,1,1989-06,1989-06,Possible error code,Character,1,Code for possible error,Possible error code (1989-only NCCS validation flag)
 ZIP,ZIP,,drop,single-year,1,1989-06,1989-06,Zip Code,Character,10,ZIP code.,Full ZIP from 1989-only dictionary; superseded by zip5 in later years
-ADDRESS,ADDRESS,,drop,alias,0,,,,,,,Discovered in raw 2013-07 file (not in scraped dictionaries); concatenated street address redundant with STREET
+ADDRESS,ADDRESS,STREET,rename,alias,0,,,,,,,"Discovered in raw 2013-07 file (not in scraped dictionaries); mailing delivery line (street or PO box). Present 2009-01 and 2009-10 through 2022-08; sole street source in legacy files (no legacy file has a STREET column). Previously mis-dropped as redundant-with-STREET; fixed per issue #29."
 EPOST,EPOST,,drop,nccs-flag,0,,,,,,,Discovered in raw 2013-07 file (not in scraped dictionaries); NCCS e-postcard (990-N) status flag
 FISYR_IMAGE,FISYR_IMAGE,,drop,nccs-curated,0,,,,,,,Discovered in raw 2013-07 file (not in scraped dictionaries); NCCS fiscal year of 990 image (post-2006)
 IRS990N,IRS990n,,drop,nccs-flag,0,,,,,,,Discovered in raw 2013-07 file (not in scraped dictionaries); 990-N filer indicator (0/1)

--- a/docs/quality-reports/index.html
+++ b/docs/quality-reports/index.html
@@ -66,7 +66,7 @@
 
   <div class="description">
     <p>Quality reports for the IRS Business Master File (BMF) data processing pipelines. Each report contains completeness metrics, validation results, and summary statistics for the processed data.</p>
-    <p class="meta">Index generated 2026-07-01 20:30 UTC &middot; 122 total reports</p>
+    <p class="meta">Index generated 2026-07-24 20:42 EDT &middot; 122 total reports</p>
   </div>
 
   <h2>Unified BMF</h2>


### PR DESCRIPTION
Fixes #29.

**ADR 0041** (UrbanInstitute/nccs-contracts#63) — additive schema on the `processed/bmf-legacy/` surface.

## What

- `XWALK-BMF-V2.0.csv`: `ADDRESS` disposition `drop,alias` → `rename` to `STREET` (the crosswalk's established alias pattern). ADDRESS is the mailing delivery line, present in 58 vintages (2009-01, 2009-10..2022-08); no legacy file has a STREET column, so the 'redundant with STREET' drop silently destroyed the only street source.
- `load_crosswalk_v2()` now rejects any `drop`+`alias` row (an alias of a current-schema concept must rename, never drop) — tested both directions.
- Pipeline control flags (`ENABLE_S3_UPLOAD` et al.) are now `exists()`-guarded so caller overrides stick; previously a local validation run with `ENABLE_S3_UPLOAD <- FALSE` still attempted production S3 writes (blocked only by missing credentials).
- Legacy `_manifest.json` upload now logs success only on a TRUE return and aborts on failure, instead of unconditionally claiming success.

## Validation (local run, 2013-07)

- Exactly **8 additive columns** vs the published artifact (`org_addr_street`, `org_addr_street_raw`, `org_addr_is_po_box`, `org_addr_is_rural_route`, `org_addr_has_special_chars`, `org_addr_missing_number`, `org_addr_full`, `org_addr_is_missing`); zero removals; identical row count (1,427,584).
- `org_addr_street_raw` populated on all but 3 rows; 26.6% PO boxes (consistent with raw-file sampling); quality gate PASSED.

## Not in this PR

Data re-publish (58 vintages, EC2), Unified BMF rebuild, geocoding cycle, and the address-resolved crosswalk are tracked as S2-S5 on the nccs-contracts BACKLOG under ADR 0041.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wk6KC3y4i7T1W652rJudgB