### PR TITLE
feat: address-resolved crosswalk - long-format address log (ADR 0042)

### DIFF
--- a/R/publish_address_resolved_crosswalk.R
+++ b/R/publish_address_resolved_crosswalk.R
@@ -1,0 +1,54 @@
+# ============================================================================
+# publish_address_resolved_crosswalk.R
+#
+# Publish the address-resolved crosswalk to S3. Thin wrapper over
+# R/publish_crosswalk.R::publish_crosswalk().
+#
+# Outputs (S3) under crosswalks/address-resolved/:
+#   address_resolved_crosswalk.parquet   (machine contract)
+#   address_resolved_crosswalk.csv       (web catalog / spreadsheet users)
+#   _manifest.json                       (ADR 0014)
+#
+# Per ADR 0041 §4 + ADR 0016 (consumer-composes): a SEPARATE per-EIN artifact
+# consumers join to the master by `ein`; address-history columns are
+# deliberately NOT added to the Unified BMF. Contract:
+# nccs-contracts/contracts/address-resolved-crosswalk.yml.
+#
+# Run:
+#   source("R/config.R"); source("R/manifest.R")
+#   source("R/publish_crosswalk.R"); source("R/publish_address_resolved_crosswalk.R")
+#   publish_address_resolved_crosswalk(dry_run = TRUE)   # inspect first
+#   publish_address_resolved_crosswalk()                 # live write
+# ============================================================================
+
+#' Publish the address-resolved crosswalk (see `publish_crosswalk()`).
+#'
+#' @param crosswalk_path Local parquet (default: data/crosswalks/address_resolved_crosswalk.parquet).
+#' @param s3_prefix      S3 key prefix; must end in "/".
+#' @param bucket         S3 bucket.
+#' @param vintage        Build vintage tag (default: today's YYYY_MM).
+#' @param dry_run        If TRUE, print the plan but touch nothing on S3.
+#' @return Invisibly `list(manifest, uploaded, skipped)`.
+#' @export
+publish_address_resolved_crosswalk <- function(
+    crosswalk_path = here::here("data", "crosswalks", "address_resolved_crosswalk.parquet"),
+    s3_prefix      = "crosswalks/address-resolved/",
+    bucket         = BMF_S3_BUCKET,
+    vintage        = format(Sys.Date(), "%Y_%m"),
+    dry_run        = FALSE) {
+
+  # Inputs: the raw address fields from the intermediate parquets of BOTH
+  # pipelines, aggregated verbatim (no cleaner dependency to pin — the raw
+  # fields are vintage-invariant). Legacy street coverage requires the
+  # ADR 0041 street re-publish to have landed.
+  inputs <- list(
+    list(uri  = sprintf("s3://%s/intermediate/bmf/", bucket),
+         note = "current-pipeline intermediate parquets (all vintages): org_addr_*_raw"),
+    list(uri  = sprintf("s3://%s/intermediate/bmf-legacy/", bucket),
+         note = "legacy-pipeline intermediate parquets (all vintages, post-ADR-0041 street re-publish): org_addr_*_raw"),
+    manifest_input_repo("R/ein.R"))   # ADR 0036: ein_prefixed/EIN2 renderings
+
+  publish_crosswalk(parquet_path = crosswalk_path, s3_prefix = s3_prefix,
+                    inputs = inputs, vintage = vintage,
+                    bucket = bucket, dry_run = dry_run)
+}

--- a/docs/reference/address-data-invariants.md
+++ b/docs/reference/address-data-invariants.md
@@ -1,0 +1,39 @@
+# Address-data invariants (rules for any address-related operation)
+
+Codified 2026-07-26 after the address-log zip-format incident. These apply
+to the address-resolved crosswalk, the geocoding export/merge, and any
+future operation that joins or aggregates addresses across the two BMF
+pipelines.
+
+## The incident, in one paragraph
+
+The address log's first build grouped spells on raw ZIP. Current-pipeline
+raw ZIPs are ZIP+4; legacy raw ZIPs are 5-digit. Identical addresses
+therefore format-split into separate spells: ~1.78M phantom rows, an
+inflated multi-address rate, and exactly ZERO spells matching across
+pipelines: a mechanically impossible statistic that exposed the broken
+key before publish.
+
+## Rules
+
+1. **Never join or group raw address fields across pipelines without
+   format normalization.** Minimum: ZIP truncated to 5 digits; strings
+   upper-cased and trimmed with empty-to-NULL. (The CLEANED columns,
+   `org_addr_zip5` etc., are already consistent because both pipelines
+   run the same transform: prefer them when raw fidelity is not
+   required.)
+2. **Every cross-pipeline address aggregation must assert a cross-source
+   match floor.** At production scale, organizations alive across the
+   2023 pipeline transition MUST produce matching tuples; a near-zero
+   cross-source share means the key is broken, not that the data is
+   strange. The builder hard-fails below a 1% floor.
+3. **Format invariants are cheap, assert them**: zip5 length <= 5,
+   spell ranks contiguous per EIN, EIN renderings bijective.
+4. **Sample-match against source before publish**:
+   `scripts/validate_address_crosswalk.R` verifies random spell-0 rows
+   byte-match the master BMF's raw values and runs the full invariant
+   suite; run it after every build, before every publish.
+
+The general principle (standing rule 14): when a slow-cost defect class
+is found, leave behind a fast detector. Zero-cross-source was that
+detector for join-key breakage; it is now a build-stopping gate.

--- a/docs/reference/address-data-invariants.md
+++ b/docs/reference/address-data-invariants.md
@@ -1,39 +1,98 @@
 # Address-data invariants (rules for any address-related operation)
 
-Codified 2026-07-26 after the address-log zip-format incident. These apply
-to the address-resolved crosswalk, the geocoding export/merge, and any
-future operation that joins or aggregates addresses across the two BMF
-pipelines.
+Codified 2026-07-26 after the address-log zip-format incident, extended
+2026-07-28 after the leading-zero finding. These apply to the
+address-resolved crosswalk, the geocoding export/merge, and any future
+operation that joins or aggregates addresses across the two BMF pipelines.
 
-## The incident, in one paragraph
+## Vocabulary: what a "spell" is
 
-The address log's first build grouped spells on raw ZIP. Current-pipeline
-raw ZIPs are ZIP+4; legacy raw ZIPs are 5-digit. Identical addresses
-therefore format-split into separate spells: ~1.78M phantom rows, an
-inflated multi-address rate, and exactly ZERO spells matching across
-pipelines: a mechanically impossible statistic that exposed the broken
-key before publish.
+A spell is one row of the address-resolved crosswalk: a single organization
+observed at a single distinct address tuple. `spell_rank` orders an EIN's
+addresses by recency, `0` = the most recent, `1` = the one before it, so
+`spell_rank == 0` reproduces the one-row-per-EIN Unified BMF view and higher
+ranks are the address history.
+
+It is an address **tenure** aggregated over every observation of that tuple,
+not a contiguity-checked survival spell: an organization that moved away and
+later returned collapses into one row whose `first_vintage`/`last_vintage`
+spans the gap. Consumers doing event-history work should treat the vintage
+bounds as first-seen/last-seen, not as an unbroken occupancy interval.
+
+## The incident, in two paragraphs
+
+The address log's first build grouped spells on raw ZIP. Current-pipeline raw
+ZIPs carry the ZIP+4 route add-on (`02138-1234`); legacy raw ZIPs do not.
+Identical addresses therefore format-split into separate spells: ~1.78M
+phantom rows, an inflated multi-address rate, and exactly ZERO spells matching
+across pipelines, a mechanically impossible statistic that exposed the broken
+key before publish. The fix truncated ZIP to its 5-digit base.
+
+That fix was incomplete, and the follow-up is the more instructive half. Legacy
+raw ZIPs also went through a numeric round-trip that **stripped leading zeros**
+(`02138` stored as `2138`), which truncation leaves untouched. The first
+published build therefore shipped 848,048 rows with a 3-to-4 character `zip5`
+that joins to nothing, and 147,994 phantom spells, and every organization in a
+0-prefix state kept format-splitting against its own current-pipeline rows: MA,
+CT, RI, NJ, ME and NH each sat at **exactly 0.00% cross-source spells** against
+a national 15.8%. The national gate passed at 14.32% the whole time. The lesson
+is rule 3 below: an aggregate gate cannot see a stratified failure.
 
 ## Rules
 
-1. **Never join or group raw address fields across pipelines without
-   format normalization.** Minimum: ZIP truncated to 5 digits; strings
-   upper-cased and trimmed with empty-to-NULL. (The CLEANED columns,
-   `org_addr_zip5` etc., are already consistent because both pipelines
-   run the same transform: prefer them when raw fidelity is not
-   required.)
-2. **Every cross-pipeline address aggregation must assert a cross-source
-   match floor.** At production scale, organizations alive across the
-   2023 pipeline transition MUST produce matching tuples; a near-zero
-   cross-source share means the key is broken, not that the data is
-   strange. The builder hard-fails below a 1% floor.
-3. **Format invariants are cheap, assert them**: zip5 length <= 5,
-   spell ranks contiguous per EIN, EIN renderings bijective.
-4. **Sample-match against source before publish**:
+1. **Never join or group raw address fields across pipelines without format
+   normalization.** The two pipelines skew in opposite directions and both
+   skews break the key: current carries a ZIP+4 add-on, legacy has lost its
+   leading zeros. The normalization is digits-only, then first-5 if longer
+   than 5, else left-pad to 5; strings upper-cased and trimmed with
+   empty-to-NULL. Canonical implementations: `normalize_zip5_sql()` in
+   `scripts/build_address_resolved_crosswalk.R` and its R mirror
+   `normalize_zip5()` in `scripts/validate_address_crosswalk.R`. Change one,
+   change the other. **Running the same transform over both pipelines does not
+   make their output consistent**, which is the trap this rule exists for: the
+   inputs are formatted differently, so identical code produces divergent
+   results. `.clean_zip()` in `R/address.R` extracted `^\d{5}`, which a
+   leading-zero-stripped legacy ZIP cannot match, so `org_addr_zip5`,
+   `org_addr_zip` and `org_addr_full` came out NA/ZIP-less for 100% of legacy
+   rows in the 0-prefix states (ME, NH, VT, MA, RI, CT, NJ, PR, VI). Those
+   columns are published, and `org_addr_full` is what the geocoder receives.
+   `.clean_zip()` now pads 3-4 digit values before extracting; **every vintage
+   published before 2026-07-28 still carries the damage** until it is re-run.
+2. **Every cross-pipeline address aggregation must assert a cross-source match
+   floor.** Legacy vintages end `2022_08` and the current pipeline starts
+   `2023_06`. Any organization that lived across that gap without moving writes
+   the same normalized tuple on each side, so those rows must fold into a
+   single `source = 'both'` spell. At ~3.7M EINs a near-zero share is
+   mechanically impossible: it means the key is broken, not that the data is
+   strange. The builder hard-fails below a 1% floor (the healthy value is
+   ~14%).
+3. **Assert that floor per state as well as nationally.** A national average
+   hides a stratified failure: the leading-zero defect held six states at zero
+   while the national share looked healthy and the global gate passed. The
+   builder hard-fails if any state with >= 50,000 spells falls below the 1%
+   floor.
+4. **Format invariants are cheap, assert them**: `zip5` exactly 5 digits or
+   absent (not merely `<= 5`, since that weaker form is what let the short legacy
+   ZIPs through), spell ranks contiguous per EIN, EIN renderings bijective.
+5. **Sort published artifacts on the full grain.** Rank/order keys must be
+   total, not partial. DuckDB returns rows in an arbitrary order
+   (`preserve_insertion_order=false`, many threads), so tied rows land
+   differently on every rebuild, which silently changes `spell_rank` and the
+   artifact's sha256, and ADR 0014 idempotency is sha256 comparison.
+6. **Sample-match against source before publish**:
    `scripts/validate_address_crosswalk.R` verifies random spell-0 rows
-   byte-match the master BMF's raw values and runs the full invariant
-   suite; run it after every build, before every publish.
+   byte-match the Unified BMF's raw values and runs the full invariant suite;
+   run it after every build, before every publish.
+7. **A cleaner must never turn populated input into NA, and the pipeline must
+   halt when it does.** This defect class is invisible in a completeness
+   percentage (the column just looks emptier) and survives every downstream
+   stage, so it needs its own gate rather than a metric.
+   `assert_zip_integrity()` in `R/quality/post_checks.R` fails the run under
+   `STRICT_QUALITY_GATES` when a raw ZIP holding 3+ digits cleans to NA or to a
+   non-5-digit value, and reports the damage by state so a stratified failure
+   is legible. Both pipelines call it before Phases 10-11 write and upload. Any
+   future cleaner that can drop populated values deserves the same treatment.
 
-The general principle (standing rule 14): when a slow-cost defect class
-is found, leave behind a fast detector. Zero-cross-source was that
-detector for join-key breakage; it is now a build-stopping gate.
+The general principle (standing rule 14): when a slow-cost defect class is
+found, leave behind a fast detector. Zero-cross-source was that detector for
+join-key breakage; it is now a build-stopping gate, nationally and per state.

--- a/scripts/build_address_resolved_crosswalk.R
+++ b/scripts/build_address_resolved_crosswalk.R
@@ -1,0 +1,211 @@
+# ============================================================================
+# build_address_resolved_crosswalk.R
+#
+# Builds the address-resolved crosswalk: one row per EIN with its mailing
+# address resolved across EVERY vintage (current monthly + legacy), so
+# consumers can recover address history for longitudinal work (the motivating
+# request: reconstructing organizations' reported addresses by year, which the
+# one-row-per-EIN Unified BMF cannot carry). See nccs-contracts ADR 0041 §4;
+# design copies the NTEE-resolved pattern (ADR 0034): expose all resolutions,
+# no opinionated pick, separate join layer keyed on `ein` (ADR 0016).
+#
+# Design:
+#   * Aggregate the RAW address fields (org_addr_{street,city,state,zip}_raw).
+#     Raw is verbatim source and vintage-invariant — independent of which
+#     cleaner version processed the vintage — so no reprocessing is needed
+#     beyond the ADR 0041 legacy street re-publish this depends on.
+#   * Street coverage begins at the 2009 legacy vintages (earlier legacy files
+#     never carried streets — ADR 0041). Observations with a NULL street but a
+#     real city/state/zip still count as addresses; consumers see the street
+#     gap honestly instead of losing the whole early history.
+#   * Tuples are normalized only for grouping (upper + trim + empty->NULL);
+#     the exposed component values keep that normalized form.
+#   * "Expose all, no single pick": addr_current (may be NULL for EINs absent
+#     from the current pipeline), addr_most_recent, addr_first, plus the full
+#     per-address distribution with vintage spans.
+#
+# Requirements: DuckDB + httpfs, AWS creds reachable by DuckDB's credential
+# chain. Sized for the EC2 batch box (address columns are a much fatter
+# projection than ntee_code_raw); locally set DUCKDB_MEMORY_LIMIT/THREADS down.
+#   eval "$(aws configure export-credentials --profile thiya --format env)"
+#   Rscript scripts/build_address_resolved_crosswalk.R
+# ============================================================================
+
+suppressPackageStartupMessages({
+  library(DBI); library(duckdb); library(data.table); library(arrow); library(jsonlite)
+})
+library(here)
+source(here::here("R", "config.R"))                 # BMF_S3_BUCKET
+source(here::here("R", "utils", "logging.R"))
+source(here::here("R", "ein.R"))                     # ein_to_prefixed/ein_to_ein2 (ADR 0036)
+
+BUCKET   <- if (exists("BMF_S3_BUCKET")) BMF_S3_BUCKET else "nccsdata"
+REGION   <- Sys.getenv("AWS_DEFAULT_REGION", unset = "us-east-1")
+OUT_DIR  <- here::here("data", "crosswalks")
+OUT_STEM <- file.path(OUT_DIR, "address_resolved_crosswalk")
+if (!dir.exists(OUT_DIR)) dir.create(OUT_DIR, recursive = TRUE)
+
+# Env-overridable so the script can be smoke-tested against local parquet
+# fixtures (point both at file globs) before an expensive full S3 run.
+CUR_GLOB <- Sys.getenv("ADDR_XWALK_CUR_GLOB",
+                       sprintf("s3://%s/intermediate/bmf/*/*.parquet", BUCKET))
+LEG_GLOB <- Sys.getenv("ADDR_XWALK_LEG_GLOB",
+                       sprintf("s3://%s/intermediate/bmf-legacy/*/*.parquet", BUCKET))
+
+# ---------------------------------------------------------------------------
+# 1. Connect + httpfs + S3 credentials + spill config (same as ntee-resolved)
+# ---------------------------------------------------------------------------
+con <- dbConnect(duckdb::duckdb())
+on.exit(dbDisconnect(con, shutdown = TRUE), add = TRUE)
+# S3 machinery only when a glob actually targets S3 — lets the script run
+# against local parquet fixtures with no AWS credentials in scope.
+if (any(startsWith(c(CUR_GLOB, LEG_GLOB), "s3://"))) {
+  dbExecute(con, "INSTALL httpfs; LOAD httpfs;")
+  dbExecute(con, "INSTALL aws; LOAD aws;")
+  dbExecute(con, sprintf("SET s3_region='%s';", REGION))
+  dbExecute(con, "CREATE SECRET IF NOT EXISTS s3cred (TYPE S3, PROVIDER credential_chain);")
+}
+dbExecute(con, sprintf("SET temp_directory='%s';",
+                       Sys.getenv("DUCKDB_TEMP_DIR", file.path(tempdir(), "duckdb_spill"))))
+dbExecute(con, "SET preserve_insertion_order=false;")
+dbExecute(con, sprintf("SET memory_limit='%s';", Sys.getenv("DUCKDB_MEMORY_LIMIT", "9GB")))
+dbExecute(con, sprintf("SET threads=%s;",        Sys.getenv("DUCKDB_THREADS", "4")))
+
+# Same case-insensitive EIN column collision handling as ntee-resolved.
+resolve_ein_col <- function(con, glob) {
+  cols <- dbGetQuery(con, sprintf(
+    "SELECT column_name, column_type FROM (DESCRIBE SELECT * FROM read_parquet('%s'))", glob))
+  cand <- cols$column_name[tolower(cols$column_name) %in% c("ein", "ein_1") &
+                           grepl("VARCHAR", cols$column_type, ignore.case = TRUE)]
+  if (length(cand) == 0L) stop("Could not find a formatted EIN string column in ", glob)
+  if ("ein_1" %in% cand) "ein_1" else cand[[1]]
+}
+
+log_info("Resolving EIN column from schemas")
+ein_cur <- resolve_ein_col(con, CUR_GLOB)
+ein_leg <- resolve_ein_col(con, LEG_GLOB)
+log_info(sprintf("  current EIN col = %s | legacy EIN col = %s", ein_cur, ein_leg))
+
+# ---------------------------------------------------------------------------
+# 2. Observation view: one normalized address tuple per (vintage, ein).
+#    An observation counts as an address when street OR city is present.
+# ---------------------------------------------------------------------------
+norm <- function(col) sprintf("nullif(trim(upper(CAST(%s AS VARCHAR))), '')", col)
+
+obs_sql <- function(glob, src, eincol) sprintf("
+  SELECT regexp_extract(filename, '(\\d{4}_\\d{2})', 1) AS vintage_ym,
+         \"%s\" AS ein,
+         '%s'   AS src,
+         %s     AS street,
+         %s     AS city,
+         %s     AS state,
+         %s     AS zip
+  FROM read_parquet('%s', filename = true, union_by_name = true)",
+  eincol, src,
+  norm("org_addr_street_raw"), norm("org_addr_city_raw"),
+  norm("org_addr_state_raw"),  norm("org_addr_zip_raw"), glob)
+
+log_info("Building observation view over all intermediate parquets")
+dbExecute(con, sprintf("CREATE OR REPLACE TEMP VIEW obs AS %s UNION ALL BY NAME %s;",
+                       obs_sql(CUR_GLOB, "current", ein_cur),
+                       obs_sql(LEG_GLOB, "legacy",  ein_leg)))
+
+log_info("Aggregating per (ein, src, address tuple)")
+cnt <- as.data.table(dbGetQuery(con, "
+  SELECT ein, src, street, city, state, zip,
+         COUNT(*)        AS n,
+         MIN(vintage_ym) AS first_vintage,
+         MAX(vintage_ym) AS last_vintage
+  FROM obs
+  WHERE ein IS NOT NULL AND (street IS NOT NULL OR city IS NOT NULL)
+  GROUP BY ein, src, street, city, state, zip"))
+
+log_info("Computing latest-current tuple per EIN (may be NULL)")
+cur <- as.data.table(dbGetQuery(con, "
+  SELECT ein,
+         arg_max(street, vintage_ym) AS addr_current_street,
+         arg_max(city,   vintage_ym) AS addr_current_city,
+         arg_max(state,  vintage_ym) AS addr_current_state,
+         arg_max(zip,    vintage_ym) AS addr_current_zip,
+         max(vintage_ym)             AS addr_current_vintage
+  FROM obs
+  WHERE src = 'current' AND ein IS NOT NULL
+  GROUP BY ein"))
+
+log_info(sprintf("Observed: %s (ein,src,tuple) rows | %s EINs seen in current",
+                 format(nrow(cnt), big.mark = ","), format(nrow(cur), big.mark = ",")))
+
+# ---------------------------------------------------------------------------
+# 3. Resolve per EIN — most-recent / first / distribution (no single pick).
+# ---------------------------------------------------------------------------
+log_info("Resolving per-EIN fields")
+
+addr_cols <- c("street", "city", "state", "zip")
+
+# most-recent: greatest last_vintage (tie -> higher count)
+setorder(cnt, ein, -last_vintage, -n)
+most_recent <- cnt[, .SD[1L], by = ein,
+  .SDcols = c(addr_cols, "last_vintage", "src")]
+setnames(most_recent,
+  c(addr_cols, "last_vintage", "src"),
+  c(paste0("addr_most_recent_", addr_cols), "addr_most_recent_vintage",
+    "addr_most_recent_source"))
+
+# first: smallest first_vintage (tie -> higher count)
+setorder(cnt, ein, first_vintage, -n)
+first_addr <- cnt[, .SD[1L], by = ein,
+  .SDcols = c(addr_cols, "first_vintage", "src")]
+setnames(first_addr,
+  c(addr_cols, "first_vintage", "src"),
+  c(paste0("addr_first_", addr_cols), "addr_first_vintage", "addr_first_source"))
+
+# distribution (JSON keyed on the concatenated one-line address) + metadata
+cnt[, addr_line := paste(fcoalesce(street, ""), fcoalesce(city, ""),
+                         fcoalesce(state, ""), fcoalesce(zip, ""), sep = " | ")]
+dist <- cnt[, .(n = sum(n), first = min(first_vintage), last = max(last_vintage)),
+            by = .(ein, addr_line)]
+dist_json <- dist[, .(
+  addr_distribution = toJSON(setNames(
+    lapply(seq_len(.N), function(i) list(n = n[i], first = first[i], last = last[i])),
+    addr_line), auto_unbox = TRUE),
+  n_distinct_addresses = uniqueN(addr_line),
+  n_vintages_with_address = sum(n)
+), by = ein]
+
+# ---------------------------------------------------------------------------
+# 4. Assemble one row per EIN (universe = any EIN with >=1 address observed).
+# ---------------------------------------------------------------------------
+xwalk <- Reduce(function(a, b) merge(a, b, by = "ein", all = TRUE),
+                list(most_recent, first_addr, dist_json, cur))
+
+xwalk[, addr_agreement := fifelse(n_vintages_with_address == 1L, "single",
+                          fifelse(n_distinct_addresses == 1L, "unanimous", "mixed"))]
+
+# ADR 0036: additive coercion-safe EIN renderings alongside the canonical ein.
+xwalk[, ein_prefixed := ein_to_prefixed(ein)]
+xwalk[, EIN2         := ein_to_ein2(ein)]
+
+setcolorder(xwalk, c("ein", "ein_prefixed", "EIN2",
+  paste0("addr_current_", addr_cols), "addr_current_vintage",
+  paste0("addr_most_recent_", addr_cols), "addr_most_recent_vintage", "addr_most_recent_source",
+  paste0("addr_first_", addr_cols), "addr_first_vintage", "addr_first_source",
+  "addr_distribution", "n_distinct_addresses", "n_vintages_with_address",
+  "addr_agreement"))
+
+log_info(sprintf("Resolved crosswalk: %s EINs", format(nrow(xwalk), big.mark = ",")))
+
+# ---------------------------------------------------------------------------
+# 5. Write parquet + csv (publish via R/publish_address_resolved_crosswalk.R)
+# ---------------------------------------------------------------------------
+arrow::write_parquet(xwalk, paste0(OUT_STEM, ".parquet"), compression = "zstd")
+data.table::fwrite(xwalk, paste0(OUT_STEM, ".csv"))
+log_info(sprintf("Wrote %s.{parquet,csv}", OUT_STEM))
+
+# Sanity: an EIN observed only in legacy should still resolve (addr_current
+# NULL, most-recent from legacy), and post-ADR-0041 its street should be
+# non-NULL for 2009+ vintages.
+leg_only <- xwalk[is.na(addr_current_vintage)][1L]
+if (nrow(leg_only)) log_info(sprintf(
+  "legacy-only spot check: ein=%s most_recent=%s (%s, %s) vintage=%s",
+  leg_only$ein, leg_only$addr_most_recent_street, leg_only$addr_most_recent_city,
+  leg_only$addr_most_recent_state, leg_only$addr_most_recent_vintage))

--- a/scripts/build_address_resolved_crosswalk.R
+++ b/scripts/build_address_resolved_crosswalk.R
@@ -11,12 +11,16 @@
 # Design:
 #   * Aggregate the RAW address fields (org_addr_{street,city,state,zip}_raw):
 #     verbatim source, vintage-invariant, no cleaner dependency.
-#   * One row per (EIN, distinct address tuple); spell_rank 0 = most recent
-#     (greatest last_vintage, ties to higher observation count).
-#   * ZIP is normalized to 5 digits for the spell key: current raw ZIPs are
-#     ZIP+4 while legacy are 5-digit, and without this the same address
-#     splits into two spells on format alone (caught by quality stats on the
-#     first full build: zero cross-source 'both' spells).
+#   * One row per (EIN, distinct address tuple). `spell_rank` 0 = the most
+#     recent address, 1 = the one before it, and so on, so `spell_rank == 0`
+#     reproduces the one-row-per-EIN Unified BMF view and higher ranks are the
+#     address history. A "spell" here is an address TENURE aggregated over every
+#     observation of that tuple, not a contiguity-checked survival spell: an
+#     organization that moved away and later returned collapses into one row
+#     whose first_vintage/last_vintage spans the gap.
+#   * ZIP is normalized to the shared 5-digit base for the spell key, because
+#     the two pipelines render ZIPs differently and the same address otherwise
+#     splits into two spells on format alone (see normalize_zip5_sql()).
 #   * Street coverage begins at the 2009 legacy vintages (ADR 0041); earlier
 #     observations carry NULL street with real city/state/zip, kept honestly.
 #   * Keyed on EIN2 per the maintainer's spec, with canonical ein and
@@ -33,91 +37,154 @@ suppressPackageStartupMessages({
   library(DBI); library(duckdb); library(data.table); library(arrow); library(jsonlite)
 })
 library(here)
-source(here::here("R", "config.R"))                 # BMF_S3_BUCKET
-source(here::here("R", "utils", "logging.R"))
+source(here::here("R", "config.R"))                  # BMF_S3_BUCKET
+source(here::here("R", "utils", "logging.R"))        # log_info()
 source(here::here("R", "ein.R"))                     # ein_to_prefixed/ein_to_ein2 (ADR 0036)
 
-BUCKET   <- if (exists("BMF_S3_BUCKET")) BMF_S3_BUCKET else "nccsdata"
-REGION   <- Sys.getenv("AWS_DEFAULT_REGION", unset = "us-east-1")
-OUT_DIR  <- here::here("data", "crosswalks")
-OUT_STEM <- file.path(OUT_DIR, "address_resolved_crosswalk")
-if (!dir.exists(OUT_DIR)) dir.create(OUT_DIR, recursive = TRUE)
+bucket_name      <- if (exists("BMF_S3_BUCKET")) BMF_S3_BUCKET else "nccsdata"
+aws_region       <- Sys.getenv("AWS_DEFAULT_REGION", unset = "us-east-1")
+output_directory <- here::here("data", "crosswalks")
+output_stem      <- file.path(output_directory, "address_resolved_crosswalk")
+if (!dir.exists(output_directory)) dir.create(output_directory, recursive = TRUE)
 
-# Env-overridable so the script can be smoke-tested against local parquet
-# fixtures (point both at file globs) before an expensive full S3 run.
-CUR_GLOB <- Sys.getenv("ADDR_XWALK_CUR_GLOB",
-                       sprintf("s3://%s/intermediate/bmf/*/*.parquet", BUCKET))
-LEG_GLOB <- Sys.getenv("ADDR_XWALK_LEG_GLOB",
-                       sprintf("s3://%s/intermediate/bmf-legacy/*/*.parquet", BUCKET))
+# Production-scale gates (section 2b) only bind on full runs, so local parquet
+# fixtures stay testable. A full build is ~11M rows across ~3.7M EINs.
+PRODUCTION_SCALE_ROWS      <- 1e6
+CROSS_SOURCE_SHARE_FLOOR   <- 0.01   # see section 2b for why 1% is the floor
+PER_STATE_MIN_SPELLS       <- 5e4    # states below this are too small to judge
+
+# Env-overridable so the script can be given a preliminary test against local
+# parquet fixtures (point both at file globs) before an expensive full S3 run.
+current_pipeline_glob <- Sys.getenv(
+  "ADDR_XWALK_CUR_GLOB", sprintf("s3://%s/intermediate/bmf/*/*.parquet", bucket_name))
+legacy_pipeline_glob  <- Sys.getenv(
+  "ADDR_XWALK_LEG_GLOB", sprintf("s3://%s/intermediate/bmf-legacy/*/*.parquet", bucket_name))
 
 # ---------------------------------------------------------------------------
 # 1. Connect + httpfs + S3 credentials + spill config (same as ntee-resolved)
 # ---------------------------------------------------------------------------
-con <- dbConnect(duckdb::duckdb())
-on.exit(dbDisconnect(con, shutdown = TRUE), add = TRUE)
-# S3 machinery only when a glob actually targets S3 — lets the script run
+duckdb_connection <- DBI::dbConnect(duckdb::duckdb())
+on.exit(DBI::dbDisconnect(duckdb_connection, shutdown = TRUE), add = TRUE)
+# S3 machinery only when a glob actually targets S3, which lets the script run
 # against local parquet fixtures with no AWS credentials in scope.
-if (any(startsWith(c(CUR_GLOB, LEG_GLOB), "s3://"))) {
-  dbExecute(con, "INSTALL httpfs; LOAD httpfs;")
-  dbExecute(con, "INSTALL aws; LOAD aws;")
-  dbExecute(con, sprintf("SET s3_region='%s';", REGION))
-  dbExecute(con, "CREATE SECRET IF NOT EXISTS s3cred (TYPE S3, PROVIDER credential_chain);")
+if (any(startsWith(c(current_pipeline_glob, legacy_pipeline_glob), "s3://"))) {
+  DBI::dbExecute(duckdb_connection, "INSTALL httpfs; LOAD httpfs;")
+  DBI::dbExecute(duckdb_connection, "INSTALL aws; LOAD aws;")
+  DBI::dbExecute(duckdb_connection, sprintf("SET s3_region='%s';", aws_region))
+  DBI::dbExecute(duckdb_connection,
+                 "CREATE SECRET IF NOT EXISTS s3cred (TYPE S3, PROVIDER credential_chain);")
 }
-dbExecute(con, sprintf("SET temp_directory='%s';",
-                       Sys.getenv("DUCKDB_TEMP_DIR", file.path(tempdir(), "duckdb_spill"))))
-dbExecute(con, "SET preserve_insertion_order=false;")
-dbExecute(con, sprintf("SET memory_limit='%s';", Sys.getenv("DUCKDB_MEMORY_LIMIT", "9GB")))
-dbExecute(con, sprintf("SET threads=%s;",        Sys.getenv("DUCKDB_THREADS", "4")))
+DBI::dbExecute(duckdb_connection, sprintf(
+  "SET temp_directory='%s';",
+  Sys.getenv("DUCKDB_TEMP_DIR", file.path(tempdir(), "duckdb_spill"))))
+DBI::dbExecute(duckdb_connection, "SET preserve_insertion_order=false;")
+DBI::dbExecute(duckdb_connection, sprintf(
+  "SET memory_limit='%s';", Sys.getenv("DUCKDB_MEMORY_LIMIT", "9GB")))
+DBI::dbExecute(duckdb_connection, sprintf(
+  "SET threads=%s;", Sys.getenv("DUCKDB_THREADS", "4")))
 
-# Same case-insensitive EIN column collision handling as ntee-resolved.
-resolve_ein_col <- function(con, glob) {
-  cols <- dbGetQuery(con, sprintf(
-    "SELECT column_name, column_type FROM (DESCRIBE SELECT * FROM read_parquet('%s'))", glob))
-  cand <- cols$column_name[tolower(cols$column_name) %in% c("ein", "ein_1") &
-                           grepl("VARCHAR", cols$column_type, ignore.case = TRUE)]
-  if (length(cand) == 0L) stop("Could not find a formatted EIN string column in ", glob)
-  if ("ein_1" %in% cand) "ein_1" else cand[[1]]
+#' Pick the formatted-EIN string column out of a parquet glob's schema.
+#'
+#' Both pipelines' intermediate parquets can carry a case-colliding pair of EIN
+#' columns (`EIN` numeric-ish, `ein_1` the formatted string DuckDB renamed on
+#' collision), so the name is resolved from the schema rather than assumed.
+#' Same handling as build_ntee_resolved_crosswalk.R.
+resolve_ein_column <- function(connection, parquet_glob) {
+  # DESCRIBE -> column_name/column_type frame -> keep VARCHAR ein/ein_1 only
+  schema_columns <- DBI::dbGetQuery(connection, sprintf(
+    "SELECT column_name, column_type FROM (DESCRIBE SELECT * FROM read_parquet('%s'))",
+    parquet_glob))
+  ein_candidates <- schema_columns$column_name[
+    tolower(schema_columns$column_name) %in% c("ein", "ein_1") &
+      grepl("VARCHAR", schema_columns$column_type, ignore.case = TRUE)]
+  if (length(ein_candidates) == 0L) {
+    stop("Could not find a formatted EIN string column in ", parquet_glob)
+  }
+  if ("ein_1" %in% ein_candidates) "ein_1" else ein_candidates[[1]]
 }
 
 log_info("Resolving EIN column from schemas")
-ein_cur <- resolve_ein_col(con, CUR_GLOB)
-ein_leg <- resolve_ein_col(con, LEG_GLOB)
-log_info(sprintf("  current EIN col = %s | legacy EIN col = %s", ein_cur, ein_leg))
+current_ein_column <- resolve_ein_column(duckdb_connection, current_pipeline_glob)
+legacy_ein_column  <- resolve_ein_column(duckdb_connection, legacy_pipeline_glob)
+log_info(sprintf("  current EIN col = %s | legacy EIN col = %s",
+                 current_ein_column, legacy_ein_column))
 
 # ---------------------------------------------------------------------------
 # 2. Observation view: one normalized address tuple per (vintage, ein).
 #    An observation counts as an address when street OR city is present.
 # ---------------------------------------------------------------------------
-norm <- function(col) sprintf("nullif(trim(upper(CAST(%s AS VARCHAR))), '')", col)
 
-obs_sql <- function(glob, src, eincol) sprintf("
+#' SQL that trims/upper-cases a raw text field and maps empty string to NULL.
+normalize_text_sql <- function(column_name) {
+  sprintf("nullif(trim(upper(CAST(%s AS VARCHAR))), '')", column_name)
+}
+
+#' SQL that reduces either pipeline's raw ZIP rendering to the shared 5-digit base.
+#'
+#' The two pipelines skew in OPPOSITE directions and both skews break the spell
+#' key, so normalization has to handle each:
+#'   * current: raw ZIPs carry the ZIP+4 route add-on ("02138-1234"). The
+#'     5-digit base is the first five digits; the add-on is not part of address
+#'     identity and is not stable across vintages.
+#'   * legacy: raw ZIPs went through a numeric round-trip that STRIPPED
+#'     LEADING ZEROS ("02138" stored as "2138"). Left-padding restores them.
+#'     Without this, every organization in a 0-prefix state (MA, CT, RI, NJ, ME,
+#'     NH, PR, VI) format-splits against its own current-pipeline rows: the
+#'     2026-07-28 review measured exactly 0.00% cross-source spells in all six
+#'     of those states while the national share was 15.8%.
+#'
+#' Digits-only -> longer than 5 means ZIP+4, keep the first 5 -> otherwise
+#' left-pad back to 5. Empty/NULL input stays NULL.
+normalize_zip5_sql <- function(column_name) {
+  zip_digits <- sprintf("regexp_replace(CAST(%s AS VARCHAR), '[^0-9]', '', 'g')", column_name)
+  sprintf("CASE WHEN %s = '' THEN NULL
+                WHEN length(%s) > 5 THEN substr(%s, 1, 5)
+                ELSE lpad(%s, 5, '0') END",
+          zip_digits, zip_digits, zip_digits, zip_digits)
+}
+
+#' SQL selecting one normalized observation row per (vintage, EIN) from a glob.
+observation_select_sql <- function(parquet_glob, source_label, ein_column) {
+  sprintf("
   SELECT regexp_extract(filename, '(\\d{4}_\\d{2})', 1) AS vintage_ym,
          \"%s\" AS ein,
          '%s'   AS src,
          %s     AS street,
          %s     AS city,
          %s     AS state,
-         substr(%s, 1, 5) AS zip5
+         %s     AS zip5
   FROM read_parquet('%s', filename = true, union_by_name = true)",
-  eincol, src,
-  norm("org_addr_street_raw"), norm("org_addr_city_raw"),
-  norm("org_addr_state_raw"),  norm("org_addr_zip_raw"), glob)
+          ein_column, source_label,
+          normalize_text_sql("org_addr_street_raw"),
+          normalize_text_sql("org_addr_city_raw"),
+          normalize_text_sql("org_addr_state_raw"),
+          normalize_zip5_sql("org_addr_zip_raw"),
+          parquet_glob)
+}
 
 log_info("Building observation view over all intermediate parquets")
-dbExecute(con, sprintf("CREATE OR REPLACE TEMP VIEW obs AS %s UNION ALL BY NAME %s;",
-                       obs_sql(CUR_GLOB, "current", ein_cur),
-                       obs_sql(LEG_GLOB, "legacy",  ein_leg)))
+# Both pipelines' observation selects -> one union view the aggregate reads once
+DBI::dbExecute(duckdb_connection, sprintf(
+  "CREATE OR REPLACE TEMP VIEW obs AS %s UNION ALL BY NAME %s;",
+  observation_select_sql(current_pipeline_glob, "current", current_ein_column),
+  observation_select_sql(legacy_pipeline_glob,  "legacy",  legacy_ein_column)))
 
+# Inner GROUP BY: distinct vintages per (ein, source, address tuple).
+# Outer GROUP BY: fold the two sources together, tagging tuples seen in both.
+# n_vintages counts DISTINCT vintages rather than rows so the column name stays
+# true even if a vintage ever lands as several parquet parts or duplicate EINs.
 log_info("Aggregating per (ein, address tuple) across sources")
-spells <- as.data.table(dbGetQuery(con, "
+address_spells <- data.table::as.data.table(DBI::dbGetQuery(duckdb_connection, "
   SELECT ein, street, city, state, zip5,
-         SUM(cnt)                            AS n_vintages,
-         MIN(first_v)                        AS first_vintage,
-         MAX(last_v)                         AS last_vintage,
+         SUM(vintage_count)                  AS n_vintages,
+         MIN(first_vintage_in_source)        AS first_vintage,
+         MAX(last_vintage_in_source)         AS last_vintage,
          CASE WHEN COUNT(DISTINCT src) > 1 THEN 'both' ELSE MIN(src) END AS source
   FROM (
     SELECT ein, src, street, city, state, zip5,
-           COUNT(*) AS cnt, MIN(vintage_ym) AS first_v, MAX(vintage_ym) AS last_v
+           COUNT(DISTINCT vintage_ym) AS vintage_count,
+           MIN(vintage_ym)            AS first_vintage_in_source,
+           MAX(vintage_ym)            AS last_vintage_in_source
     FROM obs
     WHERE ein IS NOT NULL AND (street IS NOT NULL OR city IS NOT NULL)
     GROUP BY ein, src, street, city, state, zip5
@@ -125,71 +192,110 @@ spells <- as.data.table(dbGetQuery(con, "
   GROUP BY ein, street, city, state, zip5"))
 
 log_info(sprintf("Spells: %s rows across %s EINs",
-                 format(nrow(spells), big.mark = ","),
-                 format(uniqueN(spells$ein), big.mark = ",")))
+                 format(nrow(address_spells), big.mark = ","),
+                 format(data.table::uniqueN(address_spells$ein), big.mark = ",")))
 
 # ---------------------------------------------------------------------------
-# 2b. Hard invariants (systematized from the 2026-07-26 zip-format incident:
-#     a broken cross-pipeline join key produces impossible statistics, so we
-#     fail the build on them rather than hoping someone reads the quality
-#     JSON). Production-scale thresholds only apply to full runs so local
-#     fixtures stay testable.
+# 2b. Hard invariants (systematized from the 2026-07-26 zip-format incident and
+#     the 2026-07-28 leading-zero finding: a broken cross-pipeline join key
+#     produces impossible statistics, so we fail the build on them rather than
+#     hoping someone reads the quality JSON). Thresholds bind on full runs only.
 # ---------------------------------------------------------------------------
-if (any(nchar(spells$zip5) > 5, na.rm = TRUE)) {
-  stop("Invariant violated: zip5 values longer than 5 chars (normalization broken)")
+
+# A normalized ZIP is exactly five digits or absent. Anything else means
+# normalize_zip5_sql() did not fire (the 3-4 char legacy values that shipped in
+# the first published build were the tell).
+malformed_zip5_count <- address_spells[!is.na(zip5) & nchar(zip5) != 5L, .N]
+if (malformed_zip5_count > 0L) {
+  stop(sprintf(paste0("Invariant violated: %s spells carry a zip5 that is not ",
+                      "exactly 5 digits (ZIP normalization broken)."),
+               format(malformed_zip5_count, big.mark = ",")))
 }
-if (nrow(spells) > 1e6) {
-  both_share <- spells[source == "both", .N] / nrow(spells)
-  if (both_share < 0.01) {
+
+if (nrow(address_spells) > PRODUCTION_SCALE_ROWS) {
+  # Legacy vintages end 2022_08 and the current pipeline starts 2023_06. Any
+  # organization that lived on both sides of that gap without moving writes the
+  # same normalized tuple in both sources, so those rows MUST fold into a
+  # 'both' spell. At ~3.7M EINs a near-zero share is mechanically impossible
+  # and means the key is format-splitting, not that the data is strange.
+  cross_source_share <- address_spells[source == "both", .N] / nrow(address_spells)
+  if (cross_source_share < CROSS_SOURCE_SHARE_FLOOR) {
     stop(sprintf(
       paste0("Invariant violated: cross-source ('both') spells are %.3f%% of the ",
-             "table. Organizations alive across the pipeline transition MUST ",
-             "produce matching tuples; a near-zero share means the spell key is ",
-             "format-splitting (2026-07-26 incident: raw ZIP+4 vs 5-digit)."),
-      100 * both_share))
+             "table, below the %.0f%% floor. See ",
+             "docs/reference/address-data-invariants.md."),
+      100 * cross_source_share, 100 * CROSS_SOURCE_SHARE_FLOOR))
+  }
+
+  # Same test per state, because the national figure hides stratified breakage:
+  # the leading-zero defect left six states at exactly 0.00% while the national
+  # share sat at a healthy 15.8% and the global gate passed.
+  per_state_cross_source <- address_spells[
+    !is.na(state), .(spell_count = .N,
+                     cross_source_share = sum(source == "both") / .N), by = state]
+  states_below_floor <- per_state_cross_source[
+    spell_count >= PER_STATE_MIN_SPELLS & cross_source_share < CROSS_SOURCE_SHARE_FLOOR]
+  if (nrow(states_below_floor) > 0L) {
+    stop(sprintf(
+      paste0("Invariant violated: %d state(s) with >= %s spells fall below the ",
+             "%.0f%% cross-source floor (%s). A whole state at ~zero means its ",
+             "ZIP/street rendering differs between pipelines. See ",
+             "docs/reference/address-data-invariants.md."),
+      nrow(states_below_floor), format(PER_STATE_MIN_SPELLS, big.mark = ","),
+      100 * CROSS_SOURCE_SHARE_FLOOR,
+      paste(sprintf("%s %.2f%%", states_below_floor$state,
+                    100 * states_below_floor$cross_source_share), collapse = ", ")))
   }
 }
 
 # ---------------------------------------------------------------------------
 # 3. Rank spells per EIN: 0 = most recent (last_vintage desc, n desc).
+#     The full tuple is in the sort key so ordering is deterministic: DuckDB
+#     returns rows in an arbitrary order (preserve_insertion_order=false, many
+#     threads), and a partial key would let tied rows (street-less legacy
+#     spells especially) land in a different order on every rebuild, changing
+#     spell_rank and the artifact's sha256 for no data reason (ADR 0014
+#     idempotency compares sha256).
 # ---------------------------------------------------------------------------
-setorder(spells, ein, -last_vintage, -n_vintages, street, na.last = TRUE)
-spells[, spell_rank := seq_len(.N) - 1L, by = ein]
-spells[, n_distinct_addresses := .N, by = ein]
+data.table::setorder(address_spells, ein, -last_vintage, -n_vintages,
+                     street, city, state, zip5, na.last = TRUE)
+address_spells[, spell_rank           := seq_len(.N) - 1L, by = ein]
+address_spells[, n_distinct_addresses := .N,               by = ein]
 
 # ADR 0036 renderings; EIN2 leads per the maintainer's key spec.
-spells[, ein_prefixed := ein_to_prefixed(ein)]
-spells[, EIN2         := ein_to_ein2(ein)]
+address_spells[, ein_prefixed := ein_to_prefixed(ein)]
+address_spells[, EIN2         := ein_to_ein2(ein)]
 
-stopifnot(spells[, max(spell_rank) + 1L == .N, by = ein][, all(V1)])  # ranks contiguous per EIN
-
-setcolorder(spells, c("EIN2", "ein", "ein_prefixed", "spell_rank",
+data.table::setcolorder(address_spells, c("EIN2", "ein", "ein_prefixed", "spell_rank",
   "street", "city", "state", "zip5",
   "first_vintage", "last_vintage", "n_vintages", "source",
   "n_distinct_addresses"))
 
 # ---------------------------------------------------------------------------
 # 4. Write parquet + csv + quality JSON
-#    (publish via R/publish_address_resolved_crosswalk.R)
+#    (validate via scripts/validate_address_crosswalk.R, then publish via
+#     R/publish_address_resolved_crosswalk.R)
 # ---------------------------------------------------------------------------
-arrow::write_parquet(spells, paste0(OUT_STEM, ".parquet"), compression = "zstd")
-data.table::fwrite(spells, paste0(OUT_STEM, ".csv"))
+arrow::write_parquet(address_spells, paste0(output_stem, ".parquet"), compression = "zstd")
+data.table::fwrite(address_spells, paste0(output_stem, ".csv"))
 
 quality <- list(
   timestamp            = format(Sys.time(), "%Y-%m-%dT%H:%M:%S%z"),
-  total_spell_rows     = nrow(spells),
-  distinct_eins        = uniqueN(spells$ein),
-  spells_per_ein_mean  = round(nrow(spells) / uniqueN(spells$ein), 3),
-  spells_per_ein_max   = spells[, max(n_distinct_addresses)],
-  pct_eins_multi_addr  = round(100 * uniqueN(spells[n_distinct_addresses > 1L, ein]) /
-                               uniqueN(spells$ein), 2),
-  street_null_spells   = spells[is.na(street), .N],
-  source_counts        = as.list(table(spells$source)),
-  current_spells       = spells[spell_rank == 0L, .N]
+  total_spell_rows     = nrow(address_spells),
+  distinct_eins        = data.table::uniqueN(address_spells$ein),
+  spells_per_ein_mean  = round(nrow(address_spells) /
+                               data.table::uniqueN(address_spells$ein), 3),
+  spells_per_ein_max   = address_spells[, max(n_distinct_addresses)],
+  pct_eins_multi_addr  = round(100 * data.table::uniqueN(
+                                 address_spells[n_distinct_addresses > 1L, ein]) /
+                               data.table::uniqueN(address_spells$ein), 2),
+  street_null_spells   = address_spells[is.na(street), .N],
+  source_counts        = as.list(table(address_spells$source)),
+  current_spells       = address_spells[spell_rank == 0L, .N]
 )
-jsonlite::write_json(quality, paste0(OUT_STEM, "_quality.json"),
+jsonlite::write_json(quality, paste0(output_stem, "_quality.json"),
                      auto_unbox = TRUE, pretty = TRUE)
-log_info(sprintf("Wrote %s.{parquet,csv,_quality.json}", OUT_STEM))
+log_info(sprintf("Wrote %s.{parquet,csv,_quality.json}", output_stem))
 log_info(sprintf("Quality: %s spells | %s EINs | %.2f%% multi-address | max spells %d",
                  format(quality$total_spell_rows, big.mark = ","),
                  format(quality$distinct_eins, big.mark = ","),

--- a/scripts/build_address_resolved_crosswalk.R
+++ b/scripts/build_address_resolved_crosswalk.R
@@ -1,32 +1,30 @@
 # ============================================================================
 # build_address_resolved_crosswalk.R
 #
-# Builds the address-resolved crosswalk: one row per EIN with its mailing
-# address resolved across EVERY vintage (current monthly + legacy), so
-# consumers can recover address history for longitudinal work (the motivating
-# request: reconstructing organizations' reported addresses by year, which the
-# one-row-per-EIN Unified BMF cannot carry). See nccs-contracts ADR 0041 §4;
-# design copies the NTEE-resolved pattern (ADR 0034): expose all resolutions,
-# no opinionated pick, separate join layer keyed on `ein` (ADR 0016).
+# Builds the address-resolved crosswalk: a LONG-FORMAT address log, one row
+# per (EIN, address spell), ordered by recency, so consumers get each
+# organization's current and prior mailing addresses across EVERY vintage of
+# both BMF pipelines. Shape ratified by nccs-contracts ADR 0042 Decision B
+# (supersedes the ADR 0041 §4 wide/views sketch); motivating request:
+# longitudinal address research the one-row-per-EIN Unified BMF cannot serve.
 #
 # Design:
-#   * Aggregate the RAW address fields (org_addr_{street,city,state,zip}_raw).
-#     Raw is verbatim source and vintage-invariant — independent of which
-#     cleaner version processed the vintage — so no reprocessing is needed
-#     beyond the ADR 0041 legacy street re-publish this depends on.
-#   * Street coverage begins at the 2009 legacy vintages (earlier legacy files
-#     never carried streets — ADR 0041). Observations with a NULL street but a
-#     real city/state/zip still count as addresses; consumers see the street
-#     gap honestly instead of losing the whole early history.
-#   * Tuples are normalized only for grouping (upper + trim + empty->NULL);
-#     the exposed component values keep that normalized form.
-#   * "Expose all, no single pick": addr_current (may be NULL for EINs absent
-#     from the current pipeline), addr_most_recent, addr_first, plus the full
-#     per-address distribution with vintage spans.
+#   * Aggregate the RAW address fields (org_addr_{street,city,state,zip}_raw):
+#     verbatim source, vintage-invariant, no cleaner dependency.
+#   * One row per (EIN, distinct address tuple); spell_rank 0 = most recent
+#     (greatest last_vintage, ties to higher observation count).
+#   * ZIP is normalized to 5 digits for the spell key: current raw ZIPs are
+#     ZIP+4 while legacy are 5-digit, and without this the same address
+#     splits into two spells on format alone (caught by quality stats on the
+#     first full build: zero cross-source 'both' spells).
+#   * Street coverage begins at the 2009 legacy vintages (ADR 0041); earlier
+#     observations carry NULL street with real city/state/zip, kept honestly.
+#   * Keyed on EIN2 per the maintainer's spec, with canonical ein and
+#     ein_prefixed alongside (ADR 0036).
 #
-# Requirements: DuckDB + httpfs, AWS creds reachable by DuckDB's credential
-# chain. Sized for the EC2 batch box (address columns are a much fatter
-# projection than ntee_code_raw); locally set DUCKDB_MEMORY_LIMIT/THREADS down.
+# Requirements: DuckDB + httpfs, AWS creds via credential chain. The address
+# projection is fatter than ntee-resolved's single column; on a laptop set
+# DUCKDB_MEMORY_LIMIT/DUCKDB_THREADS down and expect the S3 scan to dominate.
 #   eval "$(aws configure export-credentials --profile thiya --format env)"
 #   Rscript scripts/build_address_resolved_crosswalk.R
 # ============================================================================
@@ -99,7 +97,7 @@ obs_sql <- function(glob, src, eincol) sprintf("
          %s     AS street,
          %s     AS city,
          %s     AS state,
-         %s     AS zip
+         substr(%s, 1, 5) AS zip5
   FROM read_parquet('%s', filename = true, union_by_name = true)",
   eincol, src,
   norm("org_addr_street_raw"), norm("org_addr_city_raw"),
@@ -110,102 +108,65 @@ dbExecute(con, sprintf("CREATE OR REPLACE TEMP VIEW obs AS %s UNION ALL BY NAME 
                        obs_sql(CUR_GLOB, "current", ein_cur),
                        obs_sql(LEG_GLOB, "legacy",  ein_leg)))
 
-log_info("Aggregating per (ein, src, address tuple)")
-cnt <- as.data.table(dbGetQuery(con, "
-  SELECT ein, src, street, city, state, zip,
-         COUNT(*)        AS n,
-         MIN(vintage_ym) AS first_vintage,
-         MAX(vintage_ym) AS last_vintage
-  FROM obs
-  WHERE ein IS NOT NULL AND (street IS NOT NULL OR city IS NOT NULL)
-  GROUP BY ein, src, street, city, state, zip"))
+log_info("Aggregating per (ein, address tuple) across sources")
+spells <- as.data.table(dbGetQuery(con, "
+  SELECT ein, street, city, state, zip5,
+         SUM(cnt)                            AS n_vintages,
+         MIN(first_v)                        AS first_vintage,
+         MAX(last_v)                         AS last_vintage,
+         CASE WHEN COUNT(DISTINCT src) > 1 THEN 'both' ELSE MIN(src) END AS source
+  FROM (
+    SELECT ein, src, street, city, state, zip5,
+           COUNT(*) AS cnt, MIN(vintage_ym) AS first_v, MAX(vintage_ym) AS last_v
+    FROM obs
+    WHERE ein IS NOT NULL AND (street IS NOT NULL OR city IS NOT NULL)
+    GROUP BY ein, src, street, city, state, zip5
+  )
+  GROUP BY ein, street, city, state, zip5"))
 
-log_info("Computing latest-current tuple per EIN (may be NULL)")
-cur <- as.data.table(dbGetQuery(con, "
-  SELECT ein,
-         arg_max(street, vintage_ym) AS addr_current_street,
-         arg_max(city,   vintage_ym) AS addr_current_city,
-         arg_max(state,  vintage_ym) AS addr_current_state,
-         arg_max(zip,    vintage_ym) AS addr_current_zip,
-         max(vintage_ym)             AS addr_current_vintage
-  FROM obs
-  WHERE src = 'current' AND ein IS NOT NULL
-  GROUP BY ein"))
-
-log_info(sprintf("Observed: %s (ein,src,tuple) rows | %s EINs seen in current",
-                 format(nrow(cnt), big.mark = ","), format(nrow(cur), big.mark = ",")))
+log_info(sprintf("Spells: %s rows across %s EINs",
+                 format(nrow(spells), big.mark = ","),
+                 format(uniqueN(spells$ein), big.mark = ",")))
 
 # ---------------------------------------------------------------------------
-# 3. Resolve per EIN — most-recent / first / distribution (no single pick).
+# 3. Rank spells per EIN: 0 = most recent (last_vintage desc, n desc).
 # ---------------------------------------------------------------------------
-log_info("Resolving per-EIN fields")
+setorder(spells, ein, -last_vintage, -n_vintages, street, na.last = TRUE)
+spells[, spell_rank := seq_len(.N) - 1L, by = ein]
+spells[, n_distinct_addresses := .N, by = ein]
 
-addr_cols <- c("street", "city", "state", "zip")
+# ADR 0036 renderings; EIN2 leads per the maintainer's key spec.
+spells[, ein_prefixed := ein_to_prefixed(ein)]
+spells[, EIN2         := ein_to_ein2(ein)]
 
-# most-recent: greatest last_vintage (tie -> higher count)
-setorder(cnt, ein, -last_vintage, -n)
-most_recent <- cnt[, .SD[1L], by = ein,
-  .SDcols = c(addr_cols, "last_vintage", "src")]
-setnames(most_recent,
-  c(addr_cols, "last_vintage", "src"),
-  c(paste0("addr_most_recent_", addr_cols), "addr_most_recent_vintage",
-    "addr_most_recent_source"))
-
-# first: smallest first_vintage (tie -> higher count)
-setorder(cnt, ein, first_vintage, -n)
-first_addr <- cnt[, .SD[1L], by = ein,
-  .SDcols = c(addr_cols, "first_vintage", "src")]
-setnames(first_addr,
-  c(addr_cols, "first_vintage", "src"),
-  c(paste0("addr_first_", addr_cols), "addr_first_vintage", "addr_first_source"))
-
-# distribution (JSON keyed on the concatenated one-line address) + metadata
-cnt[, addr_line := paste(fcoalesce(street, ""), fcoalesce(city, ""),
-                         fcoalesce(state, ""), fcoalesce(zip, ""), sep = " | ")]
-dist <- cnt[, .(n = sum(n), first = min(first_vintage), last = max(last_vintage)),
-            by = .(ein, addr_line)]
-dist_json <- dist[, .(
-  addr_distribution = toJSON(setNames(
-    lapply(seq_len(.N), function(i) list(n = n[i], first = first[i], last = last[i])),
-    addr_line), auto_unbox = TRUE),
-  n_distinct_addresses = uniqueN(addr_line),
-  n_vintages_with_address = sum(n)
-), by = ein]
+setcolorder(spells, c("EIN2", "ein", "ein_prefixed", "spell_rank",
+  "street", "city", "state", "zip5",
+  "first_vintage", "last_vintage", "n_vintages", "source",
+  "n_distinct_addresses"))
 
 # ---------------------------------------------------------------------------
-# 4. Assemble one row per EIN (universe = any EIN with >=1 address observed).
+# 4. Write parquet + csv + quality JSON
+#    (publish via R/publish_address_resolved_crosswalk.R)
 # ---------------------------------------------------------------------------
-xwalk <- Reduce(function(a, b) merge(a, b, by = "ein", all = TRUE),
-                list(most_recent, first_addr, dist_json, cur))
+arrow::write_parquet(spells, paste0(OUT_STEM, ".parquet"), compression = "zstd")
+data.table::fwrite(spells, paste0(OUT_STEM, ".csv"))
 
-xwalk[, addr_agreement := fifelse(n_vintages_with_address == 1L, "single",
-                          fifelse(n_distinct_addresses == 1L, "unanimous", "mixed"))]
-
-# ADR 0036: additive coercion-safe EIN renderings alongside the canonical ein.
-xwalk[, ein_prefixed := ein_to_prefixed(ein)]
-xwalk[, EIN2         := ein_to_ein2(ein)]
-
-setcolorder(xwalk, c("ein", "ein_prefixed", "EIN2",
-  paste0("addr_current_", addr_cols), "addr_current_vintage",
-  paste0("addr_most_recent_", addr_cols), "addr_most_recent_vintage", "addr_most_recent_source",
-  paste0("addr_first_", addr_cols), "addr_first_vintage", "addr_first_source",
-  "addr_distribution", "n_distinct_addresses", "n_vintages_with_address",
-  "addr_agreement"))
-
-log_info(sprintf("Resolved crosswalk: %s EINs", format(nrow(xwalk), big.mark = ",")))
-
-# ---------------------------------------------------------------------------
-# 5. Write parquet + csv (publish via R/publish_address_resolved_crosswalk.R)
-# ---------------------------------------------------------------------------
-arrow::write_parquet(xwalk, paste0(OUT_STEM, ".parquet"), compression = "zstd")
-data.table::fwrite(xwalk, paste0(OUT_STEM, ".csv"))
-log_info(sprintf("Wrote %s.{parquet,csv}", OUT_STEM))
-
-# Sanity: an EIN observed only in legacy should still resolve (addr_current
-# NULL, most-recent from legacy), and post-ADR-0041 its street should be
-# non-NULL for 2009+ vintages.
-leg_only <- xwalk[is.na(addr_current_vintage)][1L]
-if (nrow(leg_only)) log_info(sprintf(
-  "legacy-only spot check: ein=%s most_recent=%s (%s, %s) vintage=%s",
-  leg_only$ein, leg_only$addr_most_recent_street, leg_only$addr_most_recent_city,
-  leg_only$addr_most_recent_state, leg_only$addr_most_recent_vintage))
+quality <- list(
+  timestamp            = format(Sys.time(), "%Y-%m-%dT%H:%M:%S%z"),
+  total_spell_rows     = nrow(spells),
+  distinct_eins        = uniqueN(spells$ein),
+  spells_per_ein_mean  = round(nrow(spells) / uniqueN(spells$ein), 3),
+  spells_per_ein_max   = spells[, max(n_distinct_addresses)],
+  pct_eins_multi_addr  = round(100 * uniqueN(spells[n_distinct_addresses > 1L, ein]) /
+                               uniqueN(spells$ein), 2),
+  street_null_spells   = spells[is.na(street), .N],
+  source_counts        = as.list(table(spells$source)),
+  current_spells       = spells[spell_rank == 0L, .N]
+)
+jsonlite::write_json(quality, paste0(OUT_STEM, "_quality.json"),
+                     auto_unbox = TRUE, pretty = TRUE)
+log_info(sprintf("Wrote %s.{parquet,csv,_quality.json}", OUT_STEM))
+log_info(sprintf("Quality: %s spells | %s EINs | %.2f%% multi-address | max spells %d",
+                 format(quality$total_spell_rows, big.mark = ","),
+                 format(quality$distinct_eins, big.mark = ","),
+                 quality$pct_eins_multi_addr, quality$spells_per_ein_max))

--- a/scripts/build_address_resolved_crosswalk.R
+++ b/scripts/build_address_resolved_crosswalk.R
@@ -129,6 +129,28 @@ log_info(sprintf("Spells: %s rows across %s EINs",
                  format(uniqueN(spells$ein), big.mark = ",")))
 
 # ---------------------------------------------------------------------------
+# 2b. Hard invariants (systematized from the 2026-07-26 zip-format incident:
+#     a broken cross-pipeline join key produces impossible statistics, so we
+#     fail the build on them rather than hoping someone reads the quality
+#     JSON). Production-scale thresholds only apply to full runs so local
+#     fixtures stay testable.
+# ---------------------------------------------------------------------------
+if (any(nchar(spells$zip5) > 5, na.rm = TRUE)) {
+  stop("Invariant violated: zip5 values longer than 5 chars (normalization broken)")
+}
+if (nrow(spells) > 1e6) {
+  both_share <- spells[source == "both", .N] / nrow(spells)
+  if (both_share < 0.01) {
+    stop(sprintf(
+      paste0("Invariant violated: cross-source ('both') spells are %.3f%% of the ",
+             "table. Organizations alive across the pipeline transition MUST ",
+             "produce matching tuples; a near-zero share means the spell key is ",
+             "format-splitting (2026-07-26 incident: raw ZIP+4 vs 5-digit)."),
+      100 * both_share))
+  }
+}
+
+# ---------------------------------------------------------------------------
 # 3. Rank spells per EIN: 0 = most recent (last_vintage desc, n desc).
 # ---------------------------------------------------------------------------
 setorder(spells, ein, -last_vintage, -n_vintages, street, na.last = TRUE)
@@ -138,6 +160,8 @@ spells[, n_distinct_addresses := .N, by = ein]
 # ADR 0036 renderings; EIN2 leads per the maintainer's key spec.
 spells[, ein_prefixed := ein_to_prefixed(ein)]
 spells[, EIN2         := ein_to_ein2(ein)]
+
+stopifnot(spells[, max(spell_rank) + 1L == .N, by = ein][, all(V1)])  # ranks contiguous per EIN
 
 setcolorder(spells, c("EIN2", "ein", "ein_prefixed", "spell_rank",
   "street", "city", "state", "zip5",

--- a/scripts/validate_address_crosswalk.R
+++ b/scripts/validate_address_crosswalk.R
@@ -1,0 +1,59 @@
+# ============================================================================
+# validate_address_crosswalk.R
+#
+# Standing invariant suite for the address-resolved crosswalk (see
+# docs/reference/address-data-invariants.md). Run after every build,
+# before every publish:
+#   Rscript scripts/validate_address_crosswalk.R
+# Env: ADDR_XWALK_PARQUET, MASTER_PARQUET override the default paths.
+# Exits nonzero on any violation.
+# ============================================================================
+
+suppressPackageStartupMessages({library(arrow); library(data.table)})
+library(here)
+source(here::here("R", "utils", "logging.R"))
+source(here::here("R", "ein.R"))
+
+xp <- Sys.getenv("ADDR_XWALK_PARQUET",
+                 here::here("data", "crosswalks", "address_resolved_crosswalk.parquet"))
+mp <- Sys.getenv("MASTER_PARQUET", "")
+
+x <- setDT(read_parquet(xp))
+fail <- character(0)
+chk <- function(ok, msg) if (!isTRUE(ok)) fail <<- c(fail, msg) else log_info(paste("PASS:", msg))
+
+chk(all(nchar(x$zip5) <= 5, na.rm = TRUE), "zip5 length <= 5")
+chk(x[, max(spell_rank) + 1L == .N, by = ein][, all(V1)], "spell ranks contiguous per EIN")
+chk(anyDuplicated(x[, .(ein, street, city, state, zip5)]) == 0, "no duplicate spell tuples per EIN")
+chk(x[, all(EIN2 == ein_to_ein2(ein))], "EIN2 consistent with canonical ein")
+chk(x[, all(ein_prefixed == ein_to_prefixed(ein))], "ein_prefixed consistent with canonical ein")
+if (nrow(x) > 1e6) {
+  both_share <- x[source == "both", .N] / nrow(x)
+  chk(both_share >= 0.01,
+      sprintf("cross-source spell share %.2f%% >= 1%% floor", 100 * both_share))
+}
+
+# Sample-match spell-0 against the master BMF raw values (current-source orgs)
+if (nzchar(mp) && file.exists(mp)) {
+  m <- setDT(read_parquet(mp, col_select = c(
+    "EIN2", "org_addr_street_raw", "org_addr_city_raw", "org_addr_zip_raw", "bmf_source")))
+  set.seed(42)
+  samp <- sample(m[bmf_source == "current" & !is.na(org_addr_street_raw), EIN2],
+                 min(1000L, m[bmf_source == "current", .N]))
+  j <- merge(x[spell_rank == 0L & EIN2 %in% samp],
+             m[EIN2 %in% samp], by = "EIN2")
+  match_ok <- j[, mean(
+    toupper(trimws(org_addr_street_raw)) == street &
+    toupper(trimws(org_addr_city_raw))   == city &
+    substr(org_addr_zip_raw, 1, 5)       == zip5, na.rm = TRUE)]
+  chk(match_ok > 0.99,
+      sprintf("spell-0 sample match vs master raw: %.2f%% (n=%d)", 100 * match_ok, nrow(j)))
+} else {
+  log_info("SKIP: master parquet not provided (set MASTER_PARQUET for the sample-match check)")
+}
+
+if (length(fail)) {
+  for (f in fail) log_info(paste("FAIL:", f))
+  stop(sprintf("Address crosswalk validation: %d failure(s)", length(fail)))
+}
+log_info("Address crosswalk validation: all checks passed")

--- a/scripts/validate_address_crosswalk.R
+++ b/scripts/validate_address_crosswalk.R
@@ -5,55 +5,178 @@
 # docs/reference/address-data-invariants.md). Run after every build,
 # before every publish:
 #   Rscript scripts/validate_address_crosswalk.R
-# Env: ADDR_XWALK_PARQUET, MASTER_PARQUET override the default paths.
 # Exits nonzero on any violation.
+#
+# Inputs (both are build outputs, read from disk, so this runs standalone in CI
+# or a fresh shell with nothing left over in the R session):
+#   ADDR_XWALK_PARQUET  the crosswalk being checked. Written by
+#                       scripts/build_address_resolved_crosswalk.R to
+#                       data/crosswalks/address_resolved_crosswalk.parquet.
+#   UNIFIED_PARQUET     the Unified BMF (ADR 0037; still written to data/master/
+#                       by R/run_master_pipeline.R until that rename finishes).
+#                       It is the source of truth the crosswalk is checked
+#                       against. Optional and unset by default, because it is a
+#                       multi-GB file usually absent on a laptop. When it is
+#                       missing that one check is skipped rather than failed, so
+#                       everything else still runs locally.
 # ============================================================================
 
-suppressPackageStartupMessages({library(arrow); library(data.table)})
+suppressPackageStartupMessages({library(arrow); library(data.table); library(purrr)})
 library(here)
-source(here::here("R", "utils", "logging.R"))
-source(here::here("R", "ein.R"))
+source(here::here("R", "utils", "logging.R"))        # log_info()
+source(here::here("R", "ein.R"))                     # ein_to_prefixed/ein_to_ein2 (ADR 0036)
 
-xp <- Sys.getenv("ADDR_XWALK_PARQUET",
-                 here::here("data", "crosswalks", "address_resolved_crosswalk.parquet"))
-mp <- Sys.getenv("MASTER_PARQUET", "")
+crosswalk_parquet_path <- Sys.getenv(
+  "ADDR_XWALK_PARQUET",
+  here::here("data", "crosswalks", "address_resolved_crosswalk.parquet"))
+unified_parquet_path <- Sys.getenv("UNIFIED_PARQUET", "")
 
-x <- setDT(read_parquet(xp))
-fail <- character(0)
-chk <- function(ok, msg) if (!isTRUE(ok)) fail <<- c(fail, msg) else log_info(paste("PASS:", msg))
+# Some checks only make sense on a full build (~11M rows). A small test file
+# skips them so the suite stays runnable against local fixtures.
+PRODUCTION_SCALE_ROWS    <- 1e6
+CROSS_SOURCE_SHARE_FLOOR <- 0.01
+PER_STATE_MIN_SPELLS     <- 5e4
+SAMPLE_MATCH_FLOOR       <- 0.99
+SAMPLE_SIZE              <- 1000L
 
-chk(all(nchar(x$zip5) <= 5, na.rm = TRUE), "zip5 length <= 5")
-chk(x[, max(spell_rank) + 1L == .N, by = ein][, all(V1)], "spell ranks contiguous per EIN")
-chk(anyDuplicated(x[, .(ein, street, city, state, zip5)]) == 0, "no duplicate spell tuples per EIN")
-chk(x[, all(EIN2 == ein_to_ein2(ein))], "EIN2 consistent with canonical ein")
-chk(x[, all(ein_prefixed == ein_to_prefixed(ein))], "ein_prefixed consistent with canonical ein")
-if (nrow(x) > 1e6) {
-  both_share <- x[source == "both", .N] / nrow(x)
-  chk(both_share >= 0.01,
-      sprintf("cross-source spell share %.2f%% >= 1%% floor", 100 * both_share))
+address_crosswalk <- data.table::setDT(arrow::read_parquet(crosswalk_parquet_path))
+
+#' Reduce a raw ZIP to the 5-digit form the crosswalk keys on.
+#'
+#' The same rule the builder applies in SQL (normalize_zip5_sql): keep digits
+#' only, take the first five (dropping the ZIP+4 add-on the current pipeline
+#' carries), and put back any leading zero the legacy pipeline dropped. Change
+#' one of the two and change the other.
+normalize_zip5 <- function(raw_zip) {
+  zip_base <- substr(gsub("[^0-9]", "", raw_zip), 1, 5)
+  data.table::fifelse(zip_base == "", NA_character_,
+                      stringr::str_pad(zip_base, width = 5, side = "left", pad = "0"))
 }
 
-# Sample-match spell-0 against the master BMF raw values (current-source orgs)
-if (nzchar(mp) && file.exists(mp)) {
-  m <- setDT(read_parquet(mp, col_select = c(
+# Every check is collected into one named vector, then reported together, so a
+# run tells you everything that is wrong rather than stopping at the first
+# problem. The name of each element is the message logged for it.
+check_results <- c(
+  # A ZIP is five digits or it is absent. A shorter one means a legacy ZIP kept
+  # its missing leading zero; a longer one means a ZIP+4 add-on survived. Either
+  # way the same address stops matching itself across the two pipelines.
+  "zip5 is exactly 5 digits or absent" =
+    address_crosswalk[!is.na(zip5) & nchar(zip5) != 5L, .N] == 0L,
+
+  # spell_rank puts an organization's addresses in order, most recent first:
+  # 0 is where it is now, 1 is where it was before that. So an organization
+  # with 4 addresses must have ranks 0,1,2,3 and nothing missing or repeated.
+  "spell ranks contiguous per EIN" =
+    address_crosswalk[, max(spell_rank) + 1L == .N, by = ein][, all(V1)],
+
+  # One row per organization per address is the whole point of the table, so
+  # the same address must not appear twice for the same organization.
+  "no duplicate spell tuples per EIN" =
+    anyDuplicated(address_crosswalk[, .(ein, street, city, state, zip5)]) == 0L,
+
+  # EIN2 and ein_prefixed are just the canonical EIN written differently
+  # (ADR 0036), so rebuilding them from `ein` has to reproduce the published
+  # columns exactly. If it does not, anyone joining on EIN2 gets the wrong
+  # organization.
+  "EIN2 consistent with canonical ein" =
+    address_crosswalk[, all(EIN2 == ein_to_ein2(ein))],
+  "ein_prefixed consistent with canonical ein" =
+    address_crosswalk[, all(ein_prefixed == ein_to_prefixed(ein))]
+)
+
+# ---------------------------------------------------------------------------
+# Is the address history actually joined up across the two pipelines?
+#
+# The purpose of the floor: this table is built by matching addresses from the
+# legacy pipeline against addresses from the current one, and if that matching
+# quietly stops working, the table still looks completely normal. It has the
+# expected number of rows and no missing values. The only visible symptom is
+# that organizations stop appearing in both pipelines at once, so `source`
+# says 'legacy' or 'current' but almost never 'both'.
+#
+# That is a symptom we can put a number on. The legacy pipeline stops at
+# 2022_08 and the current one starts at 2023_06, so any organization that was
+# around on both sides of that gap and did not move writes down the same
+# address twice, and the build folds those into a single 'both' row. Across
+# 3.7M organizations that has to happen a lot: the real figure is about 14%.
+# It cannot fall near zero for any innocent reason, so a floor of 1% is a
+# tripwire that only a broken match can trip. Both times the address matching
+# has broken, this is what caught it.
+# ---------------------------------------------------------------------------
+if (nrow(address_crosswalk) > PRODUCTION_SCALE_ROWS) {
+  cross_source_share <- address_crosswalk[source == "both", .N] / nrow(address_crosswalk)
+  check_results[sprintf("cross-source spell share %.2f%% >= %.0f%% floor",
+                        100 * cross_source_share, 100 * CROSS_SOURCE_SHARE_FLOOR)] <-
+    cross_source_share >= CROSS_SOURCE_SHARE_FLOOR
+
+  # The same tripwire per state, because a national average hides a failure
+  # confined to part of the country. The missing leading zeros broke every
+  # address match in MA, CT, RI, NJ, ME and NH, and the national figure stayed
+  # at a healthy 15.8% while those six states sat at zero.
+  per_state_cross_source <- address_crosswalk[
+    !is.na(state), .(spell_count = .N,
+                     cross_source_share = sum(source == "both") / .N), by = state]
+  states_below_floor <- per_state_cross_source[
+    spell_count >= PER_STATE_MIN_SPELLS & cross_source_share < CROSS_SOURCE_SHARE_FLOOR]
+  check_results[sprintf("no large state below the %.0f%% cross-source floor%s",
+                        100 * CROSS_SOURCE_SHARE_FLOOR,
+                        if (nrow(states_below_floor) > 0L) {
+                          sprintf(" (offenders: %s)", paste(states_below_floor$state,
+                                                            collapse = ", "))
+                        } else "")] <- nrow(states_below_floor) == 0L
+}
+
+# ---------------------------------------------------------------------------
+# Does the crosswalk agree with the Unified BMF about where organizations are?
+#
+# Yes: that is exactly what this checks. The crosswalk's most recent address
+# for an organization should be the address the Unified BMF already publishes
+# for it. Take 1,000 organizations at random, compare the two, and expect
+# better than 99% agreement. It is the check that would notice the crosswalk
+# drifting away from the published source, as opposed to the checks above,
+# which only notice the crosswalk contradicting itself.
+# ---------------------------------------------------------------------------
+if (nzchar(unified_parquet_path) && file.exists(unified_parquet_path)) {
+  unified_bmf <- data.table::setDT(arrow::read_parquet(unified_parquet_path, col_select = c(
     "EIN2", "org_addr_street_raw", "org_addr_city_raw", "org_addr_zip_raw", "bmf_source")))
+
+  # Draw the sample from the rows that are actually comparable (current
+  # pipeline, street present) and size it from that same pool. Sizing it off
+  # the wider row count would ask for more organizations than the pool holds
+  # and error out.
+  eligible_ein2 <- unified_bmf[bmf_source == "current" & !is.na(org_addr_street_raw), EIN2]
   set.seed(42)
-  samp <- sample(m[bmf_source == "current" & !is.na(org_addr_street_raw), EIN2],
-                 min(1000L, m[bmf_source == "current", .N]))
-  j <- merge(x[spell_rank == 0L & EIN2 %in% samp],
-             m[EIN2 %in% samp], by = "EIN2")
-  match_ok <- j[, mean(
+  sampled_ein2 <- sample(eligible_ein2, min(SAMPLE_SIZE, length(eligible_ein2)))
+
+  # For the sampled organizations: crosswalk's most recent address on one side,
+  # Unified BMF's address on the other, matched up by EIN2.
+  joined_sample <- merge(
+    address_crosswalk[spell_rank == 0L & EIN2 %in% sampled_ein2],
+    unified_bmf[EIN2 %in% sampled_ein2], by = "EIN2")
+
+  # The Unified BMF's values get the same tidying the crosswalk applied before
+  # they are compared, otherwise the check would fail on capitalisation and ZIP
+  # formatting rather than on a genuine disagreement about the address.
+  sample_match_rate <- joined_sample[, mean(
     toupper(trimws(org_addr_street_raw)) == street &
     toupper(trimws(org_addr_city_raw))   == city &
-    substr(org_addr_zip_raw, 1, 5)       == zip5, na.rm = TRUE)]
-  chk(match_ok > 0.99,
-      sprintf("spell-0 sample match vs master raw: %.2f%% (n=%d)", 100 * match_ok, nrow(j)))
+    normalize_zip5(org_addr_zip_raw)     == zip5,
+    na.rm = TRUE)]
+  check_results[sprintf("spell-0 sample match vs Unified BMF: %.2f%% (n=%d)",
+                        100 * sample_match_rate, nrow(joined_sample))] <-
+    sample_match_rate > SAMPLE_MATCH_FLOOR
 } else {
-  log_info("SKIP: master parquet not provided (set MASTER_PARQUET for the sample-match check)")
+  log_info("SKIP: Unified BMF not provided (set UNIFIED_PARQUET for the sample-match check)")
 }
 
-if (length(fail)) {
-  for (f in fail) log_info(paste("FAIL:", f))
-  stop(sprintf("Address crosswalk validation: %d failure(s)", length(fail)))
+# Report every check, then fail the run if any of them came back FALSE.
+purrr::iwalk(check_results,
+             function(passed, description) {
+               log_info(paste(if (isTRUE(passed)) "PASS:" else "FAIL:", description))
+             })
+
+failed_checks <- names(check_results)[!vapply(check_results, isTRUE, logical(1))]
+if (length(failed_checks) > 0L) {
+  stop(sprintf("Address crosswalk validation: %d failure(s)", length(failed_checks)))
 }
 log_info("Address crosswalk validation: all checks passed")


### PR DESCRIPTION
Long format per **ADR 0042 Decision B**: one row per (EIN, address spell), `spell_rank` 0 = most recent, keyed `EIN2` with `ein`/`ein_prefixed` alongside. 11,447,794 spells across 3,687,468 EINs. 68.2% of orgs have multiple addresses across the 1989-2026 record; street-less pre-2009 legacy spells retained honestly (4.39M).

`spell_rank` orders an organization's addresses by recency, so `spell_rank == 0` reproduces the one-row-per-EIN Unified BMF view and higher ranks are the address history. It is an address tenure, not a contiguity-checked survival spell: an org that moved away and later returned collapses into one row whose vintage bounds span the gap.

**Published at** `s3://nccsdata/crosswalks/address-resolved/{v2026_07,latest}/` (parquet + CSV + ADR 0014 manifest + quality JSON), per the ADR 0042 vintage-retention convention. Confirmed by anonymous HTTPS probe: both prefixes return 206, and the flat prefix holds no objects.

**Follow-up needed on the publisher.** `publish_address_resolved_crosswalk()` defaults `s3_prefix` to the flat `crosswalks/address-resolved/`, which is not where the artifact lives; the published layout came from passing the vintage and `latest/` prefixes explicitly. Anyone following the run instructions in the file header, including whoever re-publishes after the ZIP rebuild, writes to a dead path and leaves `latest/` stale. The wrapper should encode the ADR 0042 layout rather than rely on the operator remembering it.

## Two ZIP format skews, one of which shipped

The two pipelines render ZIPs differently, and each skew breaks the spell key on its own.

**Caught before publish**: current-pipeline raw ZIPs carry the ZIP+4 route add-on while legacy ZIPs do not, so identical addresses split on format. Quality stats showed zero cross-source spells, a mechanically impossible statistic. Fixed by truncating to the 5-digit base; ~1.78M phantom spells collapsed and 1,639,662 genuine cross-pipeline spells emerged.

**Not caught, and published**: legacy raw ZIPs also went through a numeric round-trip that stripped leading zeros (`02138` stored as `2138`), which truncation leaves untouched. The published build therefore carries 848,048 rows with a 3-to-4 character `zip5` that joins to nothing, 147,994 of them phantom duplicate spells, and MA, CT, RI, NJ, ME and NH each sit at exactly 0.00% cross-source spells against a national 15.8%. The 1% national floor passed at 14.32% the entire time: an aggregate gate cannot see a failure confined to part of the country.

## What this PR changes

- `normalize_zip5_sql()`: digits-only, first-5 if longer than 5, else left-pad to 5, with an R mirror in the validator.
- `zip5` invariant tightened from `<= 5 chars` to exactly 5 digits or absent. The weaker form is what let the short values through.
- New per-state cross-source floor, in the builder as a hard stop and in the validator as a check.
- Spell ordering sorts on the full tuple. A partial key let tied rows land in a different order per rebuild, changing `spell_rank` and the sha256 that ADR 0014 idempotency compares.
- `n_vintages` counts distinct vintages rather than rows.
- Validator: sample size drawn from the pool it samples from, plain-English comments, Unified BMF naming (ADR 0037), namespacing and verbose names per CODE_CONVENTIONS.

Run against the currently published artifact, the validator fails on `zip5 is exactly 5 digits or absent` and on `MA, CT, RI, NJ, ME, NH` below the floor.

## Not merged by this PR

**The published artifact still carries the defect.** The builder fix changes what the next build produces; the file on S3 was produced by the old builder and needs a rebuild, validation and re-publish.

**The root cause is upstream and ships separately.** `.clean_zip()` in `R/address.R` extracts `^\d{5}`, which a 4-digit legacy ZIP cannot match, so it returned NA. That wipes out `org_addr_zip5`, `org_addr_zip` and the ZIP portion of `org_addr_full` for 100% of legacy rows in every 0-prefix state, across all three published BMF surfaces, and `org_addr_full` is the string the geocoder receives: ~124k organizations were geocoded with no ZIP in their address. That fix, its pipeline gate, and the re-run it implies are a separate change with their own ADR.

ADR 0042

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGRpgBc9Bf4w3zniVPxDaJ
