### PR TITLE
docs: automated geocoder service reference (retires 'manual' framing)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,12 +38,20 @@ Control flags in `run_pipeline.R`:
 - `CHECKPOINT_DIR` - Directory for checkpoints (default: "data/checkpoints")
 
 ### Run the Geocoding Workflow
+
+The geocoder is Urban's **automated, S3-event-driven service**: submitting a
+batch means putting a CSV (with a single-line `f_address` column) plus a form
+JSON in `s3://geocoding-codestar-prod/data/input-data/` and `data/form-data/`;
+a Lambda auto-starts the ArcGIS engine instance, results appear under
+`data/output-data/` (FIFO), and the instance shuts itself down. No manual
+activation anywhere. Full mechanics: `docs/reference/geocoder-service.md`.
+
 ```r
 # Phase 1: Export address batches for geocoding
 GEOCODING_MODE <- "export"
 source("R/run_geocoding.R")
 
-# ... upload to Urban Institute geocoder, download results ...
+# ... submit batches to the geocoder service, retrieve outputs (see above) ...
 
 # Phase 2: Merge geocoded results back into BMF
 GEOCODING_MODE <- "merge"

--- a/R/run_master_geocoding.R
+++ b/R/run_master_geocoding.R
@@ -4,11 +4,13 @@
 # Orchestrator for the Master BMF geocoding workflow. Two modes:
 #
 #   MASTER_GEOCODING_MODE <- "export"  ; source("R/run_master_geocoding.R")
-#   # ... upload batches to Urban geocoder, save outputs locally ...
+#   # ... submit batches to the automated geocoder service, retrieve outputs ...
 #   MASTER_GEOCODING_MODE <- "merge"   ; source("R/run_master_geocoding.R")
 #
-# Mirrors the per-month run_geocoding.R interface so the manual steps
-# feel familiar.
+# Mirrors the per-month run_geocoding.R interface. The middle step needs no
+# manual activation: the geocoder is an S3-event-driven service (drop batch
+# CSVs in s3://geocoding-codestar-prod/data/input-data/, poll
+# data/output-data/ for results). See docs/reference/geocoder-service.md.
 # ============================================================================
 
 if (!exists("MASTER_GEOCODING_MODE")) MASTER_GEOCODING_MODE <- "export"

--- a/docs/reference/geocoder-service.md
+++ b/docs/reference/geocoder-service.md
@@ -1,0 +1,64 @@
+# Urban's automated geocoder service (how BMF geocoding actually runs)
+
+Documented 2026-07-24 from `UI-Research/techforms-geocoding` (infrastructure
+repo, private) so this repo stops describing the geocoder as a "manual"
+round-trip. **The geocoder needs no manual activation.** It is an
+S3-event-driven service: putting a correctly named CSV in the right prefix is
+the entire submission step.
+
+## The system
+
+- **Frontend** (interactive use): https://tech-tools.urban.org/geocoding/
+  (repo `UI-Research/tech-aws-forms`).
+- **Infrastructure**: `UI-Research/techforms-geocoding` (SAM/Codestar:
+  Lambdas, S3 events, buckets).
+- **Engine**: a pre-built Windows EC2 instance (`geocoding-service-prod`,
+  us-east-1) with an ArcGIS StreetMap Pro license (scripts in
+  `UI-Research/geocoding-arcpy-scripts`). It is **started automatically** by
+  a Lambda when work arrives and **shuts itself down** when the queue is
+  drained. Never start/stop it by hand; never spin up a replacement.
+- **Usage dashboard**: `UI-Research/geocoder-usage-visualizer`.
+
+## Event chain (non-confidential path, the one BMF uses)
+
+1. Two objects land in the **`geocoding-codestar-prod`** bucket
+   (staging twin: `geocoding-codestar-stg`):
+   - `data/input-data/{urbanid}-{unixtimestamp}-public.csv` — the batch.
+     Must contain a column **`f_address`** with the address in single-line
+     form (`"123 Main St, Denver, CO 80202"`). All other columns ride
+     through untouched.
+   - `data/form-data/{same-stem}.json` — submission metadata. Required
+     fields: `email`, `pii` ("Yes"/"No"), `has_faddress` ("on"),
+     `has_address` ("on"), `is_human_subject` ("Yes"/"No"), `filename`
+     (system name), `original_filename`. The IRB/Y-Drive fields may be
+     empty/null when `pii` and `is_human_subject` are both "No" (always
+     the case for BMF: public IRS data).
+2. `s3:ObjectCreated` on `data/input-data/*.csv` triggers the
+   `geocoding-spinup-ec2-codestar` Lambda, which starts the engine instance
+   if it isn't already running (waits out a shutdown-in-progress first).
+3. On startup a Windows scheduled task drains the queue **FIFO** and, per
+   job, writes:
+   - `data/output-data/{same-stem}.csv` — input columns + appended geocode
+     columns.
+   - `data/log-data/{same-stem}.json` — runtime, instance size, and
+     red/yellow/green match counts.
+   Then the instance shuts itself down.
+4. `s3:ObjectCreated` on `data/output-data/*.csv` triggers the notifier
+   Lambda, which emails the `email` from the form JSON a presigned download
+   link plus an accuracy summary.
+
+There is also a confidential path (`data/input-confidential-data/...` with a
+DataSync hop to the Y drive); BMF never uses it.
+
+## What this means for this repo
+
+- `R/run_geocoding.R` / `R/run_master_geocoding.R` export batches and merge
+  results; the middle of the sandwich is fully scriptable: write batch CSVs
+  (+ form JSONs) to `s3://geocoding-codestar-prod/data/input-data/`, poll
+  `data/output-data/` for the same stems, download, merge. No human step.
+- Turnaround is queue-dependent (FIFO, one engine instance, shared
+  Urban-wide); there is no documented SLA. Poll rather than assume.
+- Batches must add the single-line `f_address` column at export time.
+- Anything that changes the geocoder itself is owned by the Urban tech team
+  via `techforms-geocoding` / `geocoding-arcpy-scripts`; this repo is a
+  client only.


### PR DESCRIPTION
Documents how Urban's geocoder actually works, from `UI-Research/techforms-geocoding`: S3-event-driven, Lambda auto-starts the pre-built ArcGIS engine instance, FIFO queue, self-stopping. No manual activation exists anywhere in the flow.

- New `docs/reference/geocoder-service.md`: bucket/prefix contract (`geocoding-codestar-prod`, `data/{input-data,form-data,output-data,log-data}/`), `{urbanid}-{unixtimestamp}-public.csv` naming, required `f_address` single-line column, form-JSON fields, event chain, and what's scriptable from this repo.
- Fixes the stale 'upload to Urban geocoder / manual steps' framing in `CLAUDE.md` and `R/run_master_geocoding.R`.

Unblocks scripting the **ADR 0041** S4 geocoding cycle end-to-end (export → S3 put → poll → merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wk6KC3y4i7T1W652rJudgB