### PR TITLE
ci: re-render pipeline guide on dataset-affecting merges (ADR 0042 §3)

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -14,6 +14,9 @@ on:
     paths:
       - 'docs/**'
       - 'data/lookup/**'
+      - 'data/crosswalks/**'
+      - 'R/**'
+      - 'scripts/**'
       - '.github/workflows/publish-docs.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
The Quarto guide already auto-publishes to Pages, but only on docs/** or lookup edits: pipeline-code and crosswalk merges left it stale. Trigger paths now include R/**, scripts/**, data/crosswalks/**. Warm-cache runs are ~3-6 min per the workflow's own notes.

ADR 0042

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wk6KC3y4i7T1W652rJudgB