### PR TITLE
fix: restore ZIP leading zeros stripped by legacy files + halt on data-destroying transforms

### DIFF
--- a/R/address.R
+++ b/R/address.R
@@ -297,6 +297,24 @@ ADDRESS_OUTPUT_COLS <- c(
   # Remove all non-numeric characters except dash
   clean <- stringr::str_replace_all(raw, "[^0-9\\-]", "")
 
+  # Restore leading zeros the legacy BMF files lost. Those files went through a
+  # numeric round-trip that dropped them, so a Boston ZIP arrives as "2138"
+  # instead of "02138". The `^\d{5}` extraction below cannot match a 4-digit
+  # string and returns NA, which used to wipe out org_addr_zip5, org_addr_zip
+  # and the ZIP portion of org_addr_full for 100% of legacy rows in every
+  # 0-prefix state (ME, NH, VT, MA, RI, CT, NJ, PR, VI) and sent those
+  # addresses to the geocoder with no ZIP at all.
+  #
+  # Only 3-4 digit values are padded: a US ZIP has at most two leading zeros
+  # (00501 is the lowest in use), so a 1-2 digit value cannot be a stripped ZIP
+  # and is left to fail rather than be invented into a plausible-looking one.
+  # ZIP integrity is gated in R/quality/post_checks.R.
+  digits_only <- stringr::str_replace_all(clean, "[^0-9]", "")
+  clean <- data.table::fifelse(
+    !is.na(digits_only) & nchar(digits_only) %in% 3:4,
+    stringr::str_pad(digits_only, width = 5, side = "left", pad = "0"),
+    clean)
+
   # Extract ZIP5 (first 5 digits)
   zip5 <- stringr::str_extract(clean, "^\\d{5}")
 

--- a/R/address.R
+++ b/R/address.R
@@ -305,15 +305,23 @@ ADDRESS_OUTPUT_COLS <- c(
   # 0-prefix state (ME, NH, VT, MA, RI, CT, NJ, PR, VI) and sent those
   # addresses to the geocoder with no ZIP at all.
   #
-  # Only 3-4 digit values are padded: a US ZIP has at most two leading zeros
-  # (00501 is the lowest in use), so a 1-2 digit value cannot be a stripped ZIP
-  # and is left to fail rather than be invented into a plausible-looking one.
+  # Only 3-4 digit values are padded to 5, and 8-digit values to 9: a US ZIP
+  # has at most two leading zeros (00501 is the lowest in use), so a 1-2 digit
+  # value cannot be a stripped ZIP, and an 8-digit undashed value can only be
+  # a ZIP+4 that lost its leading zero ("02138-1234" stored as "21381234").
+  # Without the 8->9 pad the `^\d{5}` extraction below would return "21381",
+  # a wrong-but-plausible ZIP the integrity gate cannot detect. Lengths 6, 7
+  # and 10+ have no unambiguous repair and are forced to NA rather than
+  # letting the extraction invent a plausible prefix.
   # ZIP integrity is gated in R/quality/post_checks.R.
   digits_only <- stringr::str_replace_all(clean, "[^0-9]", "")
-  clean <- data.table::fifelse(
-    !is.na(digits_only) & nchar(digits_only) %in% 3:4,
-    stringr::str_pad(digits_only, width = 5, side = "left", pad = "0"),
-    clean)
+  n_digits <- nchar(digits_only)
+  clean <- data.table::fcase(
+    is.na(digits_only), clean,
+    n_digits %in% 3:4, stringr::str_pad(digits_only, width = 5, side = "left", pad = "0"),
+    n_digits == 8L, stringr::str_pad(digits_only, width = 9, side = "left", pad = "0"),
+    n_digits %in% c(6L, 7L) | n_digits >= 10L, NA_character_,
+    default = clean)
 
   # Extract ZIP5 (first 5 digits)
   zip5 <- stringr::str_extract(clean, "^\\d{5}")

--- a/R/quality/post_checks.R
+++ b/R/quality/post_checks.R
@@ -40,9 +40,13 @@ assert_zip_integrity <- function(dt, strict = TRUE) {
     return(invisible(list(skipped = TRUE)))
   }
 
-  # raw ZIP -> digit count -> rows that SHOULD have produced a clean 5-digit ZIP
+  # raw ZIP -> digit count -> rows that SHOULD have produced a clean 5-digit
+  # ZIP. Mirrors .clean_zip(): 3-4 digits pad to a ZIP5, 5 is a ZIP5, 8 pads
+  # to a ZIP+4, 9 is a ZIP+4. Lengths 1-2, 6-7 and 10+ have no unambiguous
+  # repair, clean to NA by design, and are not violations.
   raw_digit_count <- nchar(gsub("[^0-9]", "", as.character(dt$org_addr_zip_raw)))
-  is_recoverable  <- !is.na(dt$org_addr_zip_raw) & raw_digit_count >= 3L
+  is_recoverable  <- !is.na(dt$org_addr_zip_raw) &
+    raw_digit_count %in% c(3L, 4L, 5L, 8L, 9L)
 
   dropped_rows   <- which(is_recoverable & is.na(dt$org_addr_zip5))
   malformed_rows <- which(!is.na(dt$org_addr_zip5) & nchar(dt$org_addr_zip5) != 5L)

--- a/R/quality/post_checks.R
+++ b/R/quality/post_checks.R
@@ -4,6 +4,81 @@
 # ============================================================================
 
 # ============================================================================
+# Destructive-transform gates
+#
+# A transform that turns populated input into NA output is the defect class
+# these gates exist to stop. It is invisible in a completeness percentage
+# (the column simply looks emptier), it survives every downstream stage, and
+# it reaches S3 and the geocoder before anyone notices. Unlike the advisory
+# metrics in generate_quality_report(), these HALT the run under
+# STRICT_QUALITY_GATES.
+#
+# Precedent: the ZIP gate below was written after the leading-zero incident
+# (2026-07-28), where .clean_zip() silently returned NA for every ZIP in the
+# 0-prefix states across all 55 legacy vintages, publishing them and geocoding
+# ~124k organizations with no ZIP in their address string.
+# ============================================================================
+
+#' Assert the ZIP cleaner did not destroy populated ZIP values.
+#'
+#' @description
+#' Compares the raw ZIP against the cleaned output row by row. A raw value
+#' holding at least 3 digits is a recoverable ZIP (see .clean_zip()), so a NA
+#' or non-5-digit result for such a row means the cleaner dropped real data.
+#' Reports the damage by state, because this defect class is stratified: it
+#' hits whole states at 100% while the national completeness figure barely
+#' moves, which is exactly how it went unnoticed.
+#'
+#' @param dt data.table with org_addr_zip_raw and org_addr_zip5
+#' @param strict logical; if TRUE (default) a violation aborts the run
+#'
+#' @return Invisibly, a list of the violation counts.
+#' @export
+assert_zip_integrity <- function(dt, strict = TRUE) {
+  required_columns <- c("org_addr_zip_raw", "org_addr_zip5")
+  if (!all(required_columns %in% names(dt))) {
+    return(invisible(list(skipped = TRUE)))
+  }
+
+  # raw ZIP -> digit count -> rows that SHOULD have produced a clean 5-digit ZIP
+  raw_digit_count <- nchar(gsub("[^0-9]", "", as.character(dt$org_addr_zip_raw)))
+  is_recoverable  <- !is.na(dt$org_addr_zip_raw) & raw_digit_count >= 3L
+
+  dropped_rows   <- which(is_recoverable & is.na(dt$org_addr_zip5))
+  malformed_rows <- which(!is.na(dt$org_addr_zip5) & nchar(dt$org_addr_zip5) != 5L)
+  violations     <- list(dropped = length(dropped_rows),
+                         malformed = length(malformed_rows))
+
+  if (violations$dropped == 0L && violations$malformed == 0L) {
+    log_info(sprintf("ZIP integrity: PASS (%s recoverable raw ZIPs, all cleaned to 5 digits)",
+                     format(sum(is_recoverable), big.mark = ",")))
+    return(invisible(violations))
+  }
+
+  # Damage by state, so a stratified failure is legible at a glance.
+  state_column  <- if ("org_addr_state" %in% names(dt)) "org_addr_state" else NULL
+  damage_detail <- if (!is.null(state_column)) {
+    affected_states <- sort(table(dt[[state_column]][c(dropped_rows, malformed_rows)]),
+                            decreasing = TRUE)
+    paste(sprintf("%s=%s", names(affected_states), format(as.integer(affected_states),
+                                                          big.mark = ",")),
+          collapse = " ")
+  } else "state column unavailable"
+
+  violation_message <- sprintf(
+    paste0("ZIP integrity FAILED: %s populated raw ZIPs cleaned to NA, %s cleaned to a ",
+           "non-5-digit value. By state: %s. A populated ZIP must never clean to NA; ",
+           "see .clean_zip() in R/address.R and ",
+           "docs/reference/address-data-invariants.md."),
+    format(violations$dropped, big.mark = ","),
+    format(violations$malformed, big.mark = ","),
+    damage_detail)
+
+  if (isTRUE(strict)) stop(violation_message) else warning(violation_message)
+  invisible(violations)
+}
+
+# ============================================================================
 # Module Constants
 # ============================================================================
 

--- a/R/run_legacy_pipeline.R
+++ b/R/run_legacy_pipeline.R
@@ -252,6 +252,11 @@ save_checkpoint(bmf, "07_filing")
 
 log_phase_start("POST-TRANSFORMATION VALIDATION")
 
+# Destructive-transform gate: halts here, before Phases 10-11 write and upload,
+# so a cleaner that turned populated input into NA cannot reach S3. This is the
+# pipeline the leading-zero ZIP defect ran through 55 times unchallenged.
+assert_zip_integrity(bmf, strict = STRICT_QUALITY_GATES)
+
 quality_report <- generate_quality_report(bmf, pre_check_results = pre_check_results)
 print_quality_report(quality_report)
 save_quality_report(

--- a/R/run_pipeline.R
+++ b/R/run_pipeline.R
@@ -272,6 +272,10 @@ save_checkpoint(bmf, "07_filing")
 
 log_phase_start("POST-TRANSFORMATION VALIDATION")
 
+# Destructive-transform gate: halts here, before Phases 10-11 write and upload,
+# so a cleaner that turned populated input into NA cannot reach S3.
+assert_zip_integrity(bmf, strict = STRICT_QUALITY_GATES)
+
 # Generate quality report
 quality_report <- generate_quality_report(
   bmf,

--- a/docs/reference/ec2-lessons.md
+++ b/docs/reference/ec2-lessons.md
@@ -62,3 +62,33 @@ why, and the rules that now prevent it. Complements `setup_ec2.sh` and
 - Validate re-publishes against RAW sources: the bucket has no object
   versioning, so priors are gone the moment you overwrite
   (`scripts/validate_legacy_republish.R` is the standing gate).
+
+## The expensive one: a transform that quietly emptied a column
+
+The campaign's costliest defect was not a crash. `.clean_zip()` extracted
+`^\d{5}`, legacy ZIPs had lost their leading zeros upstream (`02138` stored
+as `2138`), and the extraction returned NA. All 55 vintages published with
+no ZIP for 100% of legacy rows in the nine 0-prefix states, and ~124k
+organizations were geocoded on street, city and state alone. Nobody noticed
+for four days. Three lessons, in the order they would have caught it:
+
+- **Post-transformation checks were advisory and nothing read them.**
+  `generate_quality_report()` sets `report$passed`, and neither pipeline
+  ever looked at it: `STRICT_QUALITY_GATES` was wired only to the
+  *pre*-checks. A transform could destroy a column and the run would still
+  write, upload and report success, 55 times in a row. A metric nobody gates
+  on is a comment. `assert_zip_integrity()` in `R/quality/post_checks.R` now
+  halts the run before Phases 10-11 write.
+- **A destroyed column is invisible in a completeness percentage.** Losing
+  every ZIP in nine states moved national ZIP completeness by a few points,
+  which reads as ordinary data messiness. The detectable signal is not
+  "how full is this column" but "did populated input become NA output", so
+  compare against the input rather than against a threshold.
+- **An aggregate gate cannot see a stratified failure.** The address-log
+  build had a cross-source match floor precisely to catch broken join keys.
+  It passed at 14.32% national while MA, CT, RI, NJ, ME and NH each sat at
+  exactly 0.00%. Any national threshold over a country-wide dataset needs a
+  per-stratum twin, and the stratum here (state) was the obvious one.
+
+The general form: when a defect class is found, leave behind a fast
+detector, and make sure something actually fails when it fires.


### PR DESCRIPTION
Fixes the second ZIP skew found in the 2026-07-28 review of #32. Legacy raw files lost leading zeros upstream (`02138` stored as `2138`) and `.clean_zip()`'s `^\d{5}` extraction returned NA instead of padding, emptying `org_addr_zip5`/`org_addr_zip`/`org_addr_full` for legacy rows in ME/NH/VT/MA/RI/CT/NJ/PR/VI across all 55 vintages, breaking 848,048 published address-log rows (147,994 phantom spells), and sending ~124k orgs to the geocoder with no ZIP.

**Changes:**
- `.clean_zip()`: pad 3-4 digit values to 5 with leading zeros before extraction (1-2 digit values cannot be a stripped ZIP and are left to fail).
- New `assert_zip_integrity()` in `R/quality/post_checks.R`: destructive-transform gate that halts under `STRICT_QUALITY_GATES` when a populated raw ZIP cleans to NA or a non-5-digit value, with per-state damage counts (this defect class is stratified: whole states at 100% while national completeness barely moves).
- Both pipelines call the gate before the write/upload phases.
- ec2-lessons: the defect and why nothing caught it (`report$passed` is computed and never read; gating it is Backlog Z9).

**Verified:** gate halts on the unfixed 2013_07 vintage with per-state counts, passes after the fix.

Unblocks the Z1 rebuild campaign. See UrbanInstitute/nccs-contracts#71.

ADR 0044

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xSVPqQbRdoh8aeuqLhWtJ