### PR TITLE
Merge publisher writes v{YYYY_MM}/ + latest/ itself (Z13 + Z4, ADR 0042)

### DIFF
--- a/R/master_geocoding.R
+++ b/R/master_geocoding.R
@@ -355,9 +355,9 @@ merge_master_geocoded_results <- function(
 
     # ADR 0014 manifest, built once and uploaded alongside every prefix so
     # each copy of the artifact self-describes and re-runs are idempotent.
-    mw <- NULL
+    manifest_result <- NULL
     if (exists("write_manifest")) {
-      mw <- write_manifest(
+      manifest_result <- write_manifest(
         vintage = vintage,
         out_dir = merged_dir,
         outputs = list(
@@ -368,7 +368,7 @@ merge_master_geocoded_results <- function(
         ),
         inputs = list(list(uri = master_path))
       )
-      log_info(sprintf("Wrote manifest: %s", mw$path))
+      log_info(sprintf("Wrote manifest: %s", manifest_result$path))
     } else {
       log_warn("write_manifest() not available -- skipping _manifest.json")
     }
@@ -376,12 +376,12 @@ merge_master_geocoded_results <- function(
     # Upload one prefix's file set, skipping files whose sha256 matches the
     # remote _manifest.json already at that prefix (same idempotency pattern
     # as R/publish_crosswalk.R / publish_lookups.R).
-    put_set <- function(prefix, local_paths, keys = basename(local_paths)) {
-      remote <- if (!is.null(mw)) {
+    upload_output_set <- function(prefix, local_paths, keys = basename(local_paths)) {
+      remote <- if (!is.null(manifest_result)) {
         read_existing_manifest(paste0(prefix, "_manifest.json"), BMF_S3_BUCKET)
       } else NULL
       for (i in seq_along(local_paths)) {
-        sha <- if (!is.null(mw)) mw$manifest$files[[basename(local_paths[i])]]$sha256 else NULL
+        sha <- if (!is.null(manifest_result)) manifest_result$manifest$files[[basename(local_paths[i])]]$sha256 else NULL
         if (!is.null(remote) && !is.null(sha) &&
             manifest_unchanged(remote, keys[i], sha)) {
           log_info(sprintf("SKIP (unchanged): s3://%s/%s%s",
@@ -390,21 +390,21 @@ merge_master_geocoded_results <- function(
           upload_to_s3(local_paths[i], paste0(prefix, keys[i]))
         }
       }
-      if (!is.null(mw)) upload_to_s3(mw$path, paste0(prefix, "_manifest.json"))
+      if (!is.null(manifest_result)) upload_to_s3(manifest_result$path, paste0(prefix, "_manifest.json"))
     }
 
     # ADR 0042 layout: permanent per-build vintage folder (parquet only,
     # Decision A) + a full latest/ mirror that consumer-facing links pin to.
     vintage_prefix <- paste0(BMF_S3_UNIFIED_GEOCODING_PREFIX, "v", vintage, "/")
     latest_prefix  <- paste0(BMF_S3_UNIFIED_GEOCODING_PREFIX, "latest/")
-    put_set(vintage_prefix, parquet_path)
-    put_set(latest_prefix,  c(parquet_path, csv_path, qr_path, dict_path))
+    upload_output_set(vintage_prefix, parquet_path)
+    upload_output_set(latest_prefix,  c(parquet_path, csv_path, qr_path, dict_path))
 
     # Flat merged/ key (pre-ADR-0042 rolling build key): deprecated alias,
     # kept live for the standard 90-day window from the first versioned
     # publish (2026-07-26), then archived per ADR 0006.
     merged_prefix <- paste0(BMF_S3_UNIFIED_GEOCODING_PREFIX, "merged/")
-    put_set(merged_prefix, c(parquet_path, csv_path, qr_path, dict_path))
+    upload_output_set(merged_prefix, c(parquet_path, csv_path, qr_path, dict_path))
 
     # Old path (pre-ADR-0039), 90-day deprecation window: same content,
     # unchanged old filenames, so pinned consumers (nccsdata::nccs_read(),

--- a/R/master_geocoding.R
+++ b/R/master_geocoding.R
@@ -319,9 +319,10 @@ merge_master_geocoded_results <- function(
                           big.mark = ",")))
 
   # ---------------------------------------------------------------- write
-  # ADR 0039: renamed stem bmf_master_geocoded -> bmf_unified_geocoded,
-  # dual-written below to the new unified/ prefix and the old bmf-master/
-  # prefix (unchanged old filenames) for the 90-day deprecation window.
+  # ADR 0039: renamed stem bmf_master_geocoded -> bmf_unified_geocoded.
+  # ADR 0042: published as v{YYYY_MM}/ (parquet only) + latest/ (full set),
+  # with the flat merged/ key and the old bmf-master/ prefix (unchanged old
+  # filenames) dual-written as deprecated aliases through their windows.
   parquet_path <- file.path(merged_dir, "bmf_unified_geocoded.parquet")
   csv_path     <- file.path(merged_dir, "bmf_unified_geocoded.csv")
   qr_path      <- file.path(merged_dir, "bmf_unified_geocoded_quality_report.json")
@@ -350,16 +351,14 @@ merge_master_geocoded_results <- function(
   log_info(sprintf("Quality report:  %s", qr_path))
 
   if (s3_upload) {
-    # New path (ADR 0039): geocoding/unified-bmf/merged/, new stem + manifest.
-    new_prefix <- paste0(BMF_S3_UNIFIED_GEOCODING_PREFIX, "merged/")
-    upload_to_s3(parquet_path, paste0(new_prefix, basename(parquet_path)))
-    upload_to_s3(csv_path,     paste0(new_prefix, basename(csv_path)))
-    upload_to_s3(qr_path,      paste0(new_prefix, basename(qr_path)))
-    upload_to_s3(dict_path,    paste0(new_prefix, basename(dict_path)))
+    vintage <- format(Sys.time(), "%Y_%m")
 
+    # ADR 0014 manifest, built once and uploaded alongside every prefix so
+    # each copy of the artifact self-describes and re-runs are idempotent.
+    mw <- NULL
     if (exists("write_manifest")) {
       mw <- write_manifest(
-        vintage = format(Sys.time(), "%Y_%m"),
+        vintage = vintage,
         out_dir = merged_dir,
         outputs = list(
           list(path = parquet_path, row_count = nrow(master_geo)),
@@ -369,11 +368,43 @@ merge_master_geocoded_results <- function(
         ),
         inputs = list(list(uri = master_path))
       )
-      upload_to_s3(mw$path, paste0(new_prefix, basename(mw$path)))
       log_info(sprintf("Wrote manifest: %s", mw$path))
     } else {
       log_warn("write_manifest() not available -- skipping _manifest.json")
     }
+
+    # Upload one prefix's file set, skipping files whose sha256 matches the
+    # remote _manifest.json already at that prefix (same idempotency pattern
+    # as R/publish_crosswalk.R / publish_lookups.R).
+    put_set <- function(prefix, local_paths, keys = basename(local_paths)) {
+      remote <- if (!is.null(mw)) {
+        read_existing_manifest(paste0(prefix, "_manifest.json"), BMF_S3_BUCKET)
+      } else NULL
+      for (i in seq_along(local_paths)) {
+        sha <- if (!is.null(mw)) mw$manifest$files[[basename(local_paths[i])]]$sha256 else NULL
+        if (!is.null(remote) && !is.null(sha) &&
+            manifest_unchanged(remote, keys[i], sha)) {
+          log_info(sprintf("SKIP (unchanged): s3://%s/%s%s",
+                           BMF_S3_BUCKET, prefix, keys[i]))
+        } else {
+          upload_to_s3(local_paths[i], paste0(prefix, keys[i]))
+        }
+      }
+      if (!is.null(mw)) upload_to_s3(mw$path, paste0(prefix, "_manifest.json"))
+    }
+
+    # ADR 0042 layout: permanent per-build vintage folder (parquet only,
+    # Decision A) + a full latest/ mirror that consumer-facing links pin to.
+    vintage_prefix <- paste0(BMF_S3_UNIFIED_GEOCODING_PREFIX, "v", vintage, "/")
+    latest_prefix  <- paste0(BMF_S3_UNIFIED_GEOCODING_PREFIX, "latest/")
+    put_set(vintage_prefix, parquet_path)
+    put_set(latest_prefix,  c(parquet_path, csv_path, qr_path, dict_path))
+
+    # Flat merged/ key (pre-ADR-0042 rolling build key): deprecated alias,
+    # kept live for the standard 90-day window from the first versioned
+    # publish (2026-07-26), then archived per ADR 0006.
+    merged_prefix <- paste0(BMF_S3_UNIFIED_GEOCODING_PREFIX, "merged/")
+    put_set(merged_prefix, c(parquet_path, csv_path, qr_path, dict_path))
 
     # Old path (pre-ADR-0039), 90-day deprecation window: same content,
     # unchanged old filenames, so pinned consumers (nccsdata::nccs_read(),

--- a/R/publish_address_resolved_crosswalk.R
+++ b/R/publish_address_resolved_crosswalk.R
@@ -56,16 +56,16 @@ publish_address_resolved_crosswalk <- function(
   stopifnot(endsWith(s3_base_prefix, "/"))
 
   # ADR 0042: permanent parquet-only vintage folder + full latest/ mirror.
-  res_vintage <- publish_crosswalk(
+  vintage_publish_result <- publish_crosswalk(
     parquet_path = crosswalk_path,
     s3_prefix    = paste0(s3_base_prefix, "v", vintage, "/"),
     inputs = inputs, vintage = vintage,
     bucket = bucket, dry_run = dry_run, include_csv = FALSE)
-  res_latest <- publish_crosswalk(
+  latest_publish_result <- publish_crosswalk(
     parquet_path = crosswalk_path,
     s3_prefix    = paste0(s3_base_prefix, "latest/"),
     inputs = inputs, vintage = vintage,
     bucket = bucket, dry_run = dry_run)
 
-  invisible(list(vintage = res_vintage, latest = res_latest))
+  invisible(list(vintage = vintage_publish_result, latest = latest_publish_result))
 }

--- a/R/publish_address_resolved_crosswalk.R
+++ b/R/publish_address_resolved_crosswalk.R
@@ -4,10 +4,13 @@
 # Publish the address-resolved crosswalk to S3. Thin wrapper over
 # R/publish_crosswalk.R::publish_crosswalk().
 #
-# Outputs (S3) under crosswalks/address-resolved/:
-#   address_resolved_crosswalk.parquet   (machine contract)
-#   address_resolved_crosswalk.csv       (web catalog / spreadsheet users)
-#   _manifest.json                       (ADR 0014)
+# Outputs (S3) under crosswalks/address-resolved/, ADR 0042 layout:
+#   v{YYYY_MM}/address_resolved_crosswalk.parquet   (permanent vintage; parquet
+#                                                    only per Decision A)
+#   v{YYYY_MM}/_manifest.json                        (ADR 0014)
+#   latest/address_resolved_crosswalk.parquet        (stable consumer mirror)
+#   latest/address_resolved_crosswalk.csv            (web catalog / spreadsheets)
+#   latest/_manifest.json
 #
 # Per ADR 0041 §4 + ADR 0016 (consumer-composes): a SEPARATE per-EIN artifact
 # consumers join to the master by `ein`; address-history columns are
@@ -24,15 +27,17 @@
 #' Publish the address-resolved crosswalk (see `publish_crosswalk()`).
 #'
 #' @param crosswalk_path Local parquet (default: data/crosswalks/address_resolved_crosswalk.parquet).
-#' @param s3_prefix      S3 key prefix; must end in "/".
+#' @param s3_base_prefix Base S3 prefix; `v{vintage}/` and `latest/` are
+#'                       written beneath it (ADR 0042). Must end in "/".
 #' @param bucket         S3 bucket.
 #' @param vintage        Build vintage tag (default: today's YYYY_MM).
 #' @param dry_run        If TRUE, print the plan but touch nothing on S3.
-#' @return Invisibly `list(manifest, uploaded, skipped)`.
+#' @return Invisibly `list(vintage = ..., latest = ...)`, each a
+#'         `publish_crosswalk()` result.
 #' @export
 publish_address_resolved_crosswalk <- function(
     crosswalk_path = here::here("data", "crosswalks", "address_resolved_crosswalk.parquet"),
-    s3_prefix      = "crosswalks/address-resolved/",
+    s3_base_prefix = "crosswalks/address-resolved/",
     bucket         = BMF_S3_BUCKET,
     vintage        = format(Sys.Date(), "%Y_%m"),
     dry_run        = FALSE) {
@@ -48,7 +53,19 @@ publish_address_resolved_crosswalk <- function(
          note = "legacy-pipeline intermediate parquets (all vintages, post-ADR-0041 street re-publish): org_addr_*_raw"),
     manifest_input_repo("R/ein.R"))   # ADR 0036: ein_prefixed/EIN2 renderings
 
-  publish_crosswalk(parquet_path = crosswalk_path, s3_prefix = s3_prefix,
-                    inputs = inputs, vintage = vintage,
-                    bucket = bucket, dry_run = dry_run)
+  stopifnot(endsWith(s3_base_prefix, "/"))
+
+  # ADR 0042: permanent parquet-only vintage folder + full latest/ mirror.
+  res_vintage <- publish_crosswalk(
+    parquet_path = crosswalk_path,
+    s3_prefix    = paste0(s3_base_prefix, "v", vintage, "/"),
+    inputs = inputs, vintage = vintage,
+    bucket = bucket, dry_run = dry_run, include_csv = FALSE)
+  res_latest <- publish_crosswalk(
+    parquet_path = crosswalk_path,
+    s3_prefix    = paste0(s3_base_prefix, "latest/"),
+    inputs = inputs, vintage = vintage,
+    bucket = bucket, dry_run = dry_run)
+
+  invisible(list(vintage = res_vintage, latest = res_latest))
 }

--- a/R/publish_crosswalk.R
+++ b/R/publish_crosswalk.R
@@ -22,26 +22,34 @@
 #' @param bucket       S3 bucket.
 #' @param dry_run      If TRUE, build the manifest and print the upload plan
 #'                     (one S3 HEAD for the existing manifest) but write nothing.
+#' @param include_csv  If FALSE, publish the parquet + manifest only (ADR 0042
+#'                     Decision A: vintage folders retain parquet only).
 #' @return Invisibly `list(manifest, uploaded, skipped)`.
 #' @export
 publish_crosswalk <- function(parquet_path, s3_prefix, inputs = list(),
-                              vintage, bucket = BMF_S3_BUCKET, dry_run = FALSE) {
+                              vintage, bucket = BMF_S3_BUCKET, dry_run = FALSE,
+                              include_csv = TRUE) {
   csv_path <- sub("\\.parquet$", ".csv", parquet_path)
-  stopifnot(file.exists(parquet_path), file.exists(csv_path), endsWith(s3_prefix, "/"))
+  stopifnot(file.exists(parquet_path), endsWith(s3_prefix, "/"))
+  if (include_csv) stopifnot(file.exists(csv_path))
   if (!requireNamespace("digest",   quietly = TRUE)) stop("Package 'digest' required.")
   if (!requireNamespace("jsonlite", quietly = TRUE)) stop("Package 'jsonlite' required.")
 
   df      <- arrow::read_parquet(parquet_path)
   out_dir <- dirname(parquet_path)
   outputs <- list(
-    list(path = parquet_path, row_count = nrow(df), columns = names(df)),
-    list(path = csv_path,     row_count = nrow(df), columns = names(df)))
+    list(path = parquet_path, row_count = nrow(df), columns = names(df)))
+  if (include_csv) {
+    outputs <- c(outputs,
+      list(list(path = csv_path, row_count = nrow(df), columns = names(df))))
+  }
+  local_paths <- vapply(outputs, `[[`, character(1), "path")
 
   mw   <- write_manifest(vintage = vintage, out_dir = out_dir,
                          outputs = outputs, inputs = inputs)
   manifest      <- mw$manifest
   manifest_path <- mw$path
-  files <- c(basename(parquet_path), basename(csv_path))
+  files <- basename(local_paths)
   shas  <- vapply(files, function(f) manifest$files[[f]]$sha256, character(1))
 
   message(sprintf("Built manifest for %d rows (vintage=%s): %s",
@@ -59,12 +67,12 @@ publish_crosswalk <- function(parquet_path, s3_prefix, inputs = list(),
 
   if (dry_run) {
     message("DRY RUN: target s3://", bucket, "/", s3_prefix)
-    Map(function(l, k) put_one(l, k, TRUE), c(parquet_path, csv_path), files)
+    Map(function(l, k) put_one(l, k, TRUE), local_paths, files)
     message(sprintf("  PUT  %s_manifest.json", s3_prefix))
     return(invisible(list(manifest = manifest, uploaded = character(), skipped = character())))
   }
 
-  acts <- Map(function(l, k) put_one(l, k, FALSE), c(parquet_path, csv_path), files)
+  acts <- Map(function(l, k) put_one(l, k, FALSE), local_paths, files)
   upload_to_s3(manifest_path, paste0(s3_prefix, "_manifest.json"), bucket = bucket)
 
   uploaded <- files[unlist(acts) == "put"]; skipped <- files[unlist(acts) == "skip"]

--- a/R/publish_crosswalk.R
+++ b/R/publish_crosswalk.R
@@ -44,11 +44,10 @@ publish_crosswalk <- function(parquet_path, s3_prefix, inputs = list(),
       list(list(path = csv_path, row_count = nrow(df), columns = names(df))))
   }
   local_paths <- vapply(outputs, `[[`, character(1), "path")
-
-  mw   <- write_manifest(vintage = vintage, out_dir = out_dir,
-                         outputs = outputs, inputs = inputs)
-  manifest      <- mw$manifest
-  manifest_path <- mw$path
+  manifest_result <- write_manifest(vintage = vintage, out_dir = out_dir,
+                                    outputs = outputs, inputs = inputs)
+  manifest      <- manifest_result$manifest
+  manifest_path <- manifest_result$path
   files <- basename(local_paths)
   shas  <- vapply(files, function(f) manifest$files[[f]]$sha256, character(1))
 
@@ -56,7 +55,7 @@ publish_crosswalk <- function(parquet_path, s3_prefix, inputs = list(),
                   nrow(df), vintage, paste(files, collapse = ", ")))
 
   remote <- read_existing_manifest(paste0(s3_prefix, "_manifest.json"), bucket)
-  put_one <- function(local, key, dry) {
+  upload_if_changed <- function(local, key, dry) {
     if (manifest_unchanged(remote, key, shas[[key]])) {
       message(sprintf("SKIP (unchanged): s3://%s/%s%s", bucket, s3_prefix, key)); return("skip")
     }
@@ -67,12 +66,13 @@ publish_crosswalk <- function(parquet_path, s3_prefix, inputs = list(),
 
   if (dry_run) {
     message("DRY RUN: target s3://", bucket, "/", s3_prefix)
-    Map(function(l, k) put_one(l, k, TRUE), local_paths, files)
+    Map(function(l, k) upload_if_changed(l, k, TRUE), local_paths, files)
     message(sprintf("  PUT  %s_manifest.json", s3_prefix))
     return(invisible(list(manifest = manifest, uploaded = character(), skipped = character())))
   }
-
-  acts <- Map(function(l, k) put_one(l, k, FALSE), local_paths, files)
+  # Pair each local path with its S3 basename, upload-or-skip each, and keep
+  # the put/skip outcomes for the summary; the manifest uploads separately.
+  acts <- Map(function(l, k) upload_if_changed(l, k, FALSE), local_paths, files)
   upload_to_s3(manifest_path, paste0(s3_prefix, "_manifest.json"), bucket = bucket)
 
   uploaded <- files[unlist(acts) == "put"]; skipped <- files[unlist(acts) == "skip"]


### PR DESCRIPTION
## Summary
- **Z13**: `merge_master_geocoded_results()` now publishes the ADR 0042 layout directly: `geocoding/unified-bmf/v{YYYY_MM}/` (parquet only, Decision A) + `latest/` (full set), each with an ADR 0014 `_manifest.json`, idempotent via sha256 against the remote manifest. Until now only the flat `merged/` key and the old `bmf-master/` path were written, so `latest/` (the path the website recommends) went stale on every rebuild and the vintage/latest folders had to be populated manually (as on 2026-07-26).
- **Z4** (folded in per the backlog note): `publish_address_resolved_crosswalk()` defaults now target `crosswalks/address-resolved/{v{vintage},latest}/` instead of the dead flat prefix, so following the file-header run instructions no longer writes to a dead path and leaves `latest/` stale. `publish_crosswalk()` gains an `include_csv` flag for parquet-only vintage folders.
- Deprecation-window dual-writes unchanged: flat `merged/` (window from first versioned publish 2026-07-26) and old `geocoding/bmf-master/merged/` (ADR 0039 window from 2026-07-02).

## Testing
- `parse()` clean on all three files.
- `publish_address_resolved_crosswalk(dry_run = TRUE)` against the local 11,447,794-row artifact produces the correct two-prefix plan (parquet+manifest in the vintage folder; parquet+CSV+manifest in latest/).
- The merge-publisher path needs a live merge run to exercise; next rebuild verifies (idempotent skips expected on unchanged files).

ADR 0042

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFFFA5vSvEkVWkQYdkDLRh